### PR TITLE
feat(cli): Display repository and branch information

### DIFF
--- a/auto_commit.zsh
+++ b/auto_commit.zsh
@@ -1,7 +1,37 @@
 #!/usr/bin/env zsh
 
+# Function to display repository information
+display_repository_info() {
+    local repo_url=$(git remote get-url origin 2>/dev/null)
+    local current_branch=$(git branch --show-current 2>/dev/null)
+    
+    if [ -n "$repo_url" ]; then
+        # Extract repository name from different URL formats
+        local repo_name
+        if [[ "$repo_url" =~ github\.com[:/]([^/]+/[^/]+)(\.git)?$ ]]; then
+            repo_name="${match[1]}"
+        else
+            # Fallback: use the URL as is
+            repo_name="$repo_url"
+        fi
+        
+        echo "🏗️  Repository: $repo_name"
+    else
+        echo "🏗️  Repository: (unable to detect remote)"
+    fi
+    
+    if [ -n "$current_branch" ]; then
+        echo "🌿 Branch: $current_branch"
+    fi
+    
+    echo ""
+}
+
 # Check if there are staged changes
 if ! git diff --cached --quiet; then
+    # Display repository information
+    display_repository_info
+    
     # Get the diff for context
     staged_diff=$(git diff --cached)
     

--- a/auto_issue.zsh
+++ b/auto_issue.zsh
@@ -82,6 +82,33 @@ if ! command -v gh &> /dev/null; then
     exit 1
 fi
 
+# Function to display repository information
+display_repository_info() {
+    local repo_url=$(git remote get-url origin 2>/dev/null)
+    local current_branch=$(git branch --show-current 2>/dev/null)
+    
+    if [ -n "$repo_url" ]; then
+        # Extract repository name from different URL formats
+        local repo_name
+        if [[ "$repo_url" =~ github\.com[:/]([^/]+/[^/]+)(\.git)?$ ]]; then
+            repo_name="${match[1]}"
+        else
+            # Fallback: use the URL as is
+            repo_name="$repo_url"
+        fi
+        
+        echo "🏗️  Repository: $repo_name"
+    else
+        echo "🏗️  Repository: (unable to detect remote)"
+    fi
+    
+    if [ -n "$current_branch" ]; then
+        echo "🌿 Branch: $current_branch"
+    fi
+    
+    echo ""
+}
+
 # Function to validate that quotes are properly closed in a string
 validate_quotes() {
     local input="$1"
@@ -641,6 +668,9 @@ handle_natural_language() {
         echo "Example: ./auto_issue.zsh \"add comment to issue 8 about login fix\""
         return 1
     fi
+    
+    # Display repository information
+    display_repository_info
     
     echo "Processing natural language request..."
     

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -1,5 +1,35 @@
 #!/usr/bin/env zsh
 
+# Function to display repository information
+display_repository_info() {
+    local repo_url=$(git remote get-url origin 2>/dev/null)
+    local current_branch=$(git branch --show-current 2>/dev/null)
+    
+    if [ -n "$repo_url" ]; then
+        # Extract repository name from different URL formats
+        local repo_name
+        if [[ "$repo_url" =~ github\.com[:/]([^/]+/[^/]+)(\.git)?$ ]]; then
+            repo_name="${match[1]}"
+        else
+            # Fallback: use the URL as is
+            repo_name="$repo_url"
+        fi
+        
+        echo "🏗️  Repository: $repo_name"
+    else
+        echo "🏗️  Repository: (unable to detect remote)"
+    fi
+    
+    if [ -n "$current_branch" ]; then
+        echo "🌿 Branch: $current_branch"
+    fi
+    
+    echo ""
+}
+
+# Display repository information
+display_repository_info
+
 # Get optional prompt argument
 optional_prompt="$1"
 


### PR DESCRIPTION
- Introduce `display_repository_info` function to `auto_commit.zsh`, `auto_issue.zsh`, and `auto_pr.zsh`.
- This function extracts and displays the current repository URL and branch.
- Provides immediate context to the user about the repository they are operating on.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)