### PR TITLE
fix(auto_issue): Enhance command output and quote validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,3 +103,6 @@ git submodule update --remote  # For updates
 
 ### Attribution Pattern
 All generated content includes attribution footer for transparency and compliance with LLM usage policies.
+
+## Zsh Scripting Tips
+- If you are going to use ``` inside of zsh scripts, remember to escape it like \``` so that it doesnt accidentally open a quote block


### PR DESCRIPTION
- Refine `validate_quotes` to focus on double quotes for shell command safety.
- Add explicit instructions to LLM to output plain text for `gh` commands, preventing unintended code block interpretation.
- Document zsh scripting tips for escaping backticks in `CLAUDE.md`.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)