### PR TITLE
refactor: Streamline Gemini output processing

### DIFF
--- a/auto_commit.zsh
+++ b/auto_commit.zsh
@@ -173,7 +173,7 @@ Current staged changes:
 $staged_diff"
         
         # Generate branch name with Gemini (using prompt embedding, not pipe)
-        generated_branch_name=$(gemini -m gemini-2.5-flash --prompt "$branch_name_prompt" | tail -n +2 | tr -d '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        generated_branch_name=$(gemini -m gemini-2.5-flash --prompt "$branch_name_prompt" | tr -d '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
         
         if [ $? -ne 0 ] || [ -z "$generated_branch_name" ]; then
             echo "Failed to generate branch name. Enter manually:"
@@ -224,7 +224,7 @@ $gemini_context"
 Current staged changes:
 $staged_diff"
                     
-                    generated_branch_name=$(gemini -m gemini-2.5-flash --prompt "$branch_name_prompt" | tail -n +2 | tr -d '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                    generated_branch_name=$(gemini -m gemini-2.5-flash --prompt "$branch_name_prompt" | tr -d '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
                     if [ $? -ne 0 ] || [ -z "$generated_branch_name" ]; then
                         echo "Failed to regenerate branch name."
                     fi
@@ -287,7 +287,7 @@ if ! git diff --cached --quiet; then
             git diff --name-only --cached
 
             # Generate the raw commit message from Gemini
-            gemini_raw_msg=$(echo "$staged_diff" | gemini -m gemini-2.5-flash --prompt "$full_prompt" | tail -n +2)
+            gemini_raw_msg=$(echo "$staged_diff" | gemini -m gemini-2.5-flash --prompt "$full_prompt")
             
             # Check for generation failure before proceeding
             if [ $? -ne 0 ] || [ -z "$gemini_raw_msg" ]; then

--- a/auto_issue.zsh
+++ b/auto_issue.zsh
@@ -195,7 +195,7 @@ For body edits, if the user wants to append or prepend text, combine it with the
     echo "Generating edit commands with Gemini..."
     
     # Generate edit commands from Gemini
-    edit_commands=$(echo "$llm_prompt" | gemini -m gemini-2.5-flash --prompt "$llm_prompt" | tail -n +2)
+    edit_commands=$(echo "$llm_prompt" | gemini -m gemini-2.5-flash --prompt "$llm_prompt")
     
     if [ $? -ne 0 ] || [ -z "$edit_commands" ]; then
         echo "Failed to generate edit commands. Please try again."
@@ -285,7 +285,7 @@ CONFIDENCE: high
 Be precise and only extract what's clearly stated."
     
     # Generate intent parsing from Gemini
-    local intent_output=$(echo "$parser_prompt" | gemini -m gemini-2.5-flash --prompt "$parser_prompt" | tail -n +2)
+    local intent_output=$(echo "$parser_prompt" | gemini -m gemini-2.5-flash --prompt "$parser_prompt")
     
     if [ $? -ne 0 ] || [ -z "$intent_output" ]; then
         echo "OPERATION: unknown"
@@ -421,7 +421,7 @@ Only output the comment content, without any additional text or explanation."
     echo "Generating comment with Gemini..."
     
     # Generate comment content from Gemini
-    local comment_content=$(echo "$llm_prompt" | gemini -m gemini-2.5-flash --prompt "$llm_prompt" | tail -n +2)
+    local comment_content=$(echo "$llm_prompt" | gemini -m gemini-2.5-flash --prompt "$llm_prompt")
     
     if [ $? -ne 0 ] || [ -z "$comment_content" ]; then
         echo "Failed to generate comment. Please try again."
@@ -581,7 +581,7 @@ Make sure to include appropriate labels and assignees based on the issue type an
     echo "Generating issue creation command with Gemini..."
     
     # Generate create command from Gemini
-    create_command=$(echo "$full_prompt" | gemini -m gemini-2.5-flash --prompt "$full_prompt" | tail -n +2)
+    create_command=$(echo "$full_prompt" | gemini -m gemini-2.5-flash --prompt "$full_prompt")
     
     if [ $? -ne 0 ] || [ -z "$create_command" ]; then
         echo "Failed to generate create command. Please try again."
@@ -699,7 +699,7 @@ Only output the converted/unchanged command, no additional text.
 IMPORTANT: Output as plain text only, no code blocks or formatting."
     
     # Get converted command from Gemini
-    local converted_command=$(echo "$converter_prompt" | gemini -m gemini-2.5-flash --prompt "$converter_prompt" | tail -n +2)
+    local converted_command=$(echo "$converter_prompt" | gemini -m gemini-2.5-flash --prompt "$converter_prompt")
     
     if [ $? -ne 0 ] || [ -z "$converted_command" ]; then
         # If conversion fails, return original input

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -105,7 +105,7 @@ $commit_details"
     fi
     
     # Generate raw PR content from Gemini
-    echo "$commit_details" | gemini -m gemini-2.5-flash --prompt "$full_prompt" | tail -n +2
+    echo "$commit_details" | gemini -m gemini-2.5-flash --prompt "$full_prompt"
 }
 
 # Generate initial PR content


### PR DESCRIPTION
*   Removed `tail -n +2` from `gemini` command outputs across all scripts.
*   Improved directness and robustness of script interaction with Gemini CLI.
*   Eliminated unnecessary parsing step, assuming Gemini now provides clean output.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)