### PR TITLE
feat: Introduce gemini_clean.zsh for robust CLI output cleaning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,14 @@ This repository contains Zsh automation scripts that use the Gemini CLI to autom
 
 ## Core Scripts
 
+### gemini_clean.zsh
+Utility script for cleaning Gemini CLI responses:
+- Removes authentication-related lines that can appear at response start
+- Prevents command execution failures when auth messages get included
+- Used by all other scripts via pipe: `gemini ... | "${script_dir}/gemini_clean.zsh"`
+
+Usage: `gemini -m model --prompt "..." | ./gemini_clean.zsh`
+
 ### auto_commit.zsh
 Automated commit message generation using Gemini CLI with feedback loops:
 - Analyzes staged changes and recent commit history
@@ -97,7 +105,8 @@ git submodule update --remote  # For updates
 5. Update help documentation
 
 ### Gemini Response Handling
-- All scripts use `tail -n +2` to trim first line (handles auth-related output)
+- All scripts use `gemini_clean.zsh` utility to clean auth-related output from responses
+- Handles "Loaded cached credentials." and similar auth messages that sometimes appear
 - Retry mechanism available in auto_commit.zsh via regeneration option
 - Error checking for failed LLM calls with fallback messages
 

--- a/auto_commit.zsh
+++ b/auto_commit.zsh
@@ -227,7 +227,7 @@ Current staged changes:
 $staged_diff"
         
         # Generate branch name with Gemini (using prompt embedding, not pipe)
-        generated_branch_name=$(gemini -m gemini-2.5-flash --prompt "$branch_name_prompt" | tr -d '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        generated_branch_name=$(gemini -m gemini-2.5-flash --prompt "$branch_name_prompt" | "${script_dir}/gemini_clean.zsh" | tr -d '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
         
         if [ $? -ne 0 ] || [ -z "$generated_branch_name" ]; then
             echo "Failed to generate branch name. Enter manually:"
@@ -299,7 +299,7 @@ $gemini_context"
 Current staged changes:
 $staged_diff"
                         
-                        generated_branch_name=$(gemini -m gemini-2.5-flash --prompt "$branch_name_prompt" | tr -d '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                        generated_branch_name=$(gemini -m gemini-2.5-flash --prompt "$branch_name_prompt" | "${script_dir}/gemini_clean.zsh" | tr -d '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
                         if [ $? -ne 0 ] || [ -z "$generated_branch_name" ]; then
                             echo "Failed to regenerate branch name."
                         fi
@@ -370,7 +370,7 @@ if ! git diff --cached --quiet; then
             git diff --name-only --cached
 
             # Generate the raw commit message from Gemini
-            gemini_raw_msg=$(echo "$staged_diff" | gemini -m gemini-2.5-flash --prompt "$full_prompt")
+            gemini_raw_msg=$(echo "$staged_diff" | gemini -m gemini-2.5-flash --prompt "$full_prompt" | "${script_dir}/gemini_clean.zsh")
             
             # Check for generation failure before proceeding
             if [ $? -ne 0 ] || [ -z "$gemini_raw_msg" ]; then

--- a/auto_issue.zsh
+++ b/auto_issue.zsh
@@ -213,7 +213,7 @@ Please incorporate this feedback to improve the edit commands."
             fi
             
             # Generate edit commands from Gemini
-            edit_commands=$(echo "$final_prompt" | gemini -m gemini-2.5-flash --prompt "$final_prompt")
+            edit_commands=$(echo "$final_prompt" | gemini -m gemini-2.5-flash --prompt "$final_prompt" | "${script_dir}/gemini_clean.zsh")
             
             if [ $? -ne 0 ] || [ -z "$edit_commands" ]; then
                 echo "Failed to generate edit commands. Please try again."
@@ -341,7 +341,7 @@ CONFIDENCE: high
 Be precise and only extract what's clearly stated."
     
     # Generate intent parsing from Gemini
-    local intent_output=$(echo "$parser_prompt" | gemini -m gemini-2.5-flash --prompt "$parser_prompt")
+    local intent_output=$(echo "$parser_prompt" | gemini -m gemini-2.5-flash --prompt "$parser_prompt" | "${script_dir}/gemini_clean.zsh")
     
     if [ $? -ne 0 ] || [ -z "$intent_output" ]; then
         echo "OPERATION: unknown"
@@ -495,7 +495,7 @@ Please incorporate this feedback to improve the comment."
             fi
             
             # Generate comment content from Gemini
-            local comment_content=$(echo "$final_prompt" | gemini -m gemini-2.5-flash --prompt "$final_prompt")
+            local comment_content=$(echo "$final_prompt" | gemini -m gemini-2.5-flash --prompt "$final_prompt" | "${script_dir}/gemini_clean.zsh")
             
             if [ $? -ne 0 ] || [ -z "$comment_content" ]; then
                 echo "Failed to generate comment. Please try again."
@@ -672,7 +672,7 @@ Make sure to include appropriate labels and assignees based on the issue type an
     echo "Generating issue creation command with Gemini..."
     
     # Generate create command from Gemini
-    create_command=$(echo "$full_prompt" | gemini -m gemini-2.5-flash --prompt "$full_prompt")
+    create_command=$(echo "$full_prompt" | gemini -m gemini-2.5-flash --prompt "$full_prompt" | "${script_dir}/gemini_clean.zsh")
     
     if [ $? -ne 0 ] || [ -z "$create_command" ]; then
         echo "Failed to generate create command. Please try again."
@@ -790,7 +790,7 @@ Only output the converted/unchanged command, no additional text.
 IMPORTANT: Output as plain text only, no code blocks or formatting."
     
     # Get converted command from Gemini
-    local converted_command=$(echo "$converter_prompt" | gemini -m gemini-2.5-flash --prompt "$converter_prompt")
+    local converted_command=$(echo "$converter_prompt" | gemini -m gemini-2.5-flash --prompt "$converter_prompt" | "${script_dir}/gemini_clean.zsh")
     
     if [ $? -ne 0 ] || [ -z "$converted_command" ]; then
         # If conversion fails, return original input

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -114,7 +114,7 @@ $commit_details"
     fi
     
     # Generate raw PR content from Gemini
-    echo "$commit_details" | gemini -m gemini-2.5-flash --prompt "$full_prompt"
+    echo "$commit_details" | gemini -m gemini-2.5-flash --prompt "$full_prompt" | "${script_dir}/gemini_clean.zsh"
 }
 
 # Generate initial PR content

--- a/gemini_clean.zsh
+++ b/gemini_clean.zsh
@@ -1,0 +1,42 @@
+#!/usr/bin/env zsh
+
+# Gemini CLI Response Cleaner
+# 
+# Utility to clean Gemini CLI responses by removing authentication-related 
+# output lines that sometimes appear at the beginning of responses.
+#
+# Usage:
+#   gemini -m model --prompt "..." | ./gemini_clean.zsh
+#   echo "response with auth line" | ./gemini_clean.zsh
+#
+# Problem it solves:
+# Sometimes Gemini CLI outputs "Loaded cached credentials." as the first line,
+# which can break command execution when the response is meant to be a command.
+
+# Read input from stdin
+input=$(cat)
+
+# Check if input is empty
+if [ -z "$input" ]; then
+    # Return empty if no input
+    exit 0
+fi
+
+# Split input into lines
+lines=("${(@f)input}")
+
+# Check if first line contains authentication-related output
+first_line="${lines[1]}"
+
+# Remove first line if it matches known authentication patterns
+if [[ "$first_line" =~ ^(Loaded cached credentials\.|Authentication.*|Cached.*|Loading.*credentials) ]]; then
+    # Remove the first line and output the rest
+    if [ ${#lines[@]} -gt 1 ]; then
+        # Join remaining lines with newlines
+        printf '%s\n' "${lines[@]:1}"
+    fi
+    # If only one line and it was auth-related, output nothing
+else
+    # No auth line detected, output everything unchanged
+    echo "$input"
+fi


### PR DESCRIPTION
- Add `gemini_clean.zsh` to filter authentication messages from Gemini CLI responses.
- Integrate `gemini_clean.zsh` into `auto_commit.zsh`, `auto_issue.zsh`, and `auto_pr.zsh` for consistent and reliable output processing.
- Update `CLAUDE.md` to document the new utility and its purpose.
- Replace direct `tail -n +2` usage with the new `gemini_clean.zsh` utility.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)