### PR TITLE
feat(auto_commit): Default to branch creation on prompt

### DIFF
--- a/auto_commit.zsh
+++ b/auto_commit.zsh
@@ -254,11 +254,11 @@ $staged_diff"
                 echo ""
                 echo "Generated branch name: $generated_branch_name"
                 echo ""
-                echo "Create branch '$generated_branch_name'? [y/e/r/q] (yes / edit / regenerate / quit)"
+                echo "Create branch '$generated_branch_name'? [Y/e/r/q] (YES / edit / regenerate / quit)"
                 read -r branch_response
                 
                 case "$branch_response" in
-                    [Yy]* )
+                    [Yy]* | "" )
                         if git switch -c "$generated_branch_name"; then
                             echo "✅ Created and switched to branch '$generated_branch_name'"
                             echo ""


### PR DESCRIPTION
- Make 'yes' the default option for branch creation prompt.
- Allow pressing Enter to confirm branch creation.
- Improve user experience by streamlining the branch creation workflow.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)