### PR TITLE
Refactor(auto-pr): Improve gum helper loading robustness and PR display

### DIFF
--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -75,9 +75,29 @@ if [ -z "$commits" ]; then
     exit 1
 fi
 
-echo "Found commits to include in PR:"
-echo "$commits"
-echo ""
+# Function to display commits in formatted block
+display_commits_to_include() {
+    local commits="$1"
+    local commits_block="> **Found commits to include in PR:**"
+    
+    while IFS= read -r commit; do
+        if [ -n "$commit" ]; then
+            commits_block+=$'\n> '"$commit"
+        fi
+    done <<< "$commits"
+    
+    # Display using gum format if available, otherwise fallback to echo
+    if command -v gum &> /dev/null; then
+        echo "$commits_block" | gum format
+        echo "> \\n" | gum format
+    else
+        echo "Found commits to include in PR:"
+        echo "$commits"
+        echo ""
+    fi
+}
+
+display_commits_to_include "$commits"
 
 # Get detailed commit information for better context
 commit_details=$(git log $base_branch..$current_branch --pretty=format:"%h - %s%n%b" --no-merges)

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -124,6 +124,26 @@ $commit_details"
     echo "$commit_details" | gemini -m gemini-2.5-flash --prompt "$full_prompt" | "${script_dir}/utils/gemini_clean.zsh"
 }
 
+# Function to display PR command in formatted block
+display_pr_command() {
+    local pr_command="$1"
+    
+    # Display generated PR command in quote block format
+    local pr_cmd_header="> **Generated PR create command:**"
+    local pr_cmd_content=$(wrap_quote_block_text "$pr_command")
+    local pr_cmd_block="$pr_cmd_header"$'\n'"$pr_cmd_content"
+    
+    # Display using gum format if available, otherwise fallback to echo
+    if command -v gum &> /dev/null; then
+        echo "$pr_cmd_block" | gum format
+        echo "> \\n" | gum format
+    else
+        echo "Generated PR create command:"
+        echo "$pr_command"
+        echo ""
+    fi
+}
+
 # Generate initial PR content
 pr_content_raw=$(generate_pr_content)
 
@@ -134,9 +154,7 @@ if [ $? -eq 0 ] && [ -n "$pr_content_raw" ]; then
         # The LLM now generates a complete gh pr create command
         pr_create_command="$pr_content_raw"
 
-        echo "Generated PR create command:"
-        echo "$pr_create_command"
-        echo ""
+        display_pr_command "$pr_create_command"
         response=$(use_gum_choose "Create PR with this command?" "Yes" "Regenerate with feedback" "Quit")
         
         case "$response" in

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -75,31 +75,10 @@ if [ -z "$commits" ]; then
     exit 1
 fi
 
-# Function to display commits in formatted block
-display_commits_to_include() {
-    local commits="$1"
-    local commits_block="> **Found commits to include in PR:**"
-    
-    while IFS= read -r commit; do
-        if [ -n "$commit" ]; then
-            # Use wrap_quote_block_text to properly wrap each commit line
-            local wrapped_commit=$(wrap_quote_block_text "$commit")
-            commits_block+=$'\n'"$wrapped_commit"
-        fi
-    done <<< "$commits"
-    
-    # Display using gum format if available, otherwise fallback to echo
-    if command -v gum &> /dev/null; then
-        echo "$commits_block" | gum format
-        echo "> \\n" | gum format
-    else
-        echo "Found commits to include in PR:"
-        echo "$commits"
-        echo ""
-    fi
-}
-
-display_commits_to_include "$commits"
+# Display commits using the same pattern as auto_commit.zsh
+colored_status "Found commits to include in PR:" "info"
+git log $base_branch..$current_branch --no-merges --pretty=format:"  • %h %s"
+echo ""
 
 # Get detailed commit information for better context
 commit_details=$(git log $base_branch..$current_branch --pretty=format:"%h - %s%n%b" --no-merges)

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -82,7 +82,9 @@ display_commits_to_include() {
     
     while IFS= read -r commit; do
         if [ -n "$commit" ]; then
-            commits_block+=$'\n> '"$commit"
+            # Use wrap_quote_block_text to properly wrap each commit line
+            local wrapped_commit=$(wrap_quote_block_text "$commit")
+            commits_block+=$'\n'"$wrapped_commit"
         fi
     done <<< "$commits"
     

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -9,7 +9,12 @@ if [ -f "${script_dir}/utils/gemini_context.zsh" ]; then
 fi
 
 # Load shared gum helper functions
-source "${script_dir}/gum/gum_helpers.zsh"
+if [ -f "${script_dir}/gum/gum_helpers.zsh" ]; then
+    source "${script_dir}/gum/gum_helpers.zsh"
+else
+    echo "Error: Required gum helper functions not found at ${script_dir}/gum/gum_helpers.zsh"
+    exit 1
+fi
 
 
 # Function to check for existing pull request

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -125,26 +125,6 @@ $commit_details"
     echo "$commit_details" | gemini -m gemini-2.5-flash --prompt "$full_prompt" | "${script_dir}/utils/gemini_clean.zsh"
 }
 
-# Function to display PR command in formatted block
-display_pr_command() {
-    local pr_command="$1"
-    
-    # Display generated PR command in quote block format
-    local pr_cmd_header="> **Generated PR create command:**"
-    local pr_cmd_content=$(wrap_quote_block_text "$pr_command")
-    local pr_cmd_block="$pr_cmd_header"$'\n'"$pr_cmd_content"
-    
-    # Display using gum format if available, otherwise fallback to echo
-    if command -v gum &> /dev/null; then
-        echo "$pr_cmd_block" | gum format
-        echo "> \\n" | gum format
-    else
-        echo "Generated PR create command:"
-        echo "$pr_command"
-        echo ""
-    fi
-}
-
 # Generate initial PR content
 pr_content_raw=$(generate_pr_content)
 
@@ -155,7 +135,9 @@ if [ $? -eq 0 ] && [ -n "$pr_content_raw" ]; then
         # The LLM now generates a complete gh pr create command
         pr_create_command="$pr_content_raw"
 
-        display_pr_command "$pr_create_command"
+        echo "Generated PR create command:"
+        echo "$pr_create_command"
+        echo ""
         response=$(use_gum_choose "Create PR with this command?" "Yes" "Regenerate with feedback" "Quit")
         
         case "$response" in

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -77,7 +77,7 @@ fi
 
 # Display commits using the same pattern as auto_commit.zsh
 colored_status "Found commits to include in PR:" "info"
-git log $base_branch..$current_branch --no-merges --pretty=format:"  • %h %s"
+git log $base_branch..$current_branch --no-merges --pretty=format:"  • %h %f" | sed 's/-/ /g'
 echo ""
 
 # Get detailed commit information for better context

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -135,9 +135,18 @@ if [ $? -eq 0 ] && [ -n "$pr_content_raw" ]; then
         # The LLM now generates a complete gh pr create command
         pr_create_command="$pr_content_raw"
 
-        echo "Generated PR create command:"
-        echo "$pr_create_command"
-        echo ""
+        # Display the PR command in a formatted code block
+        if command -v gum &> /dev/null; then
+            echo ""
+            local code_block_title="**Generated PR create command:**"
+            local code_block="$pr_create_command"
+            echo "$code_block_title" | gum format
+            echo "$code_block" | gum format -t "code" -l "zsh"
+        else
+            echo "Generated PR create command:"
+            echo "$pr_create_command"
+            echo ""
+        fi
         response=$(use_gum_choose "Create PR with this command?" "Yes" "Regenerate with feedback" "Quit")
         
         case "$response" in


### PR DESCRIPTION
- **refactor(auto-pr): Improve robustness of gum helper loading**
    - Add file existence check before sourcing `gum_helpers.zsh`.
    - Print an error message and exit if `gum_helpers.zsh` is not found.
    - Prevents script failure due to missing helper file.
- **feat(auto-pr): Display generated PR command in a formatted code block**
    - Use `gum format` to display the `gh pr create` command in a visually distinct code block.
    - Fallback to plain `echo` if `gum` is not available.
    - Improves readability and user experience for the generated PR command.
- **Revert "feat(auto-pr): Use quote block for PR command display"**
    - This reverts commit f439ed9d0bfbc11945cb2e4f801d6699d0cbd990.
- **refactor(auto-pr): Improve commit message display format**
    - Changed `git log` format from `%s` to `%f` for commit subjects.
    - Replaced hyphens with spaces in commit subjects for better readability.
    - Ensures consistent and readable commit message presentation in `auto_pr.zsh`.
- **refactor(auto-pr): Align commit display with auto_commit.zsh**
    - Removed custom `display_commits_to_include` function.
    - Utilized `colored_status` and direct `git log` output for displaying commits.
    - Ensures consistent commit list presentation across scripts.
    - Simplifies commit display logic.
- **feat(auto-pr): Wrap commit messages in PR quote block**
    - Utilize `wrap_quote_block_text` to ensure proper line wrapping for individual commit messages displayed within the pull request quote block.
    - Improves the readability and formatting of the commit list in `auto_pr.zsh`.
- **feat(auto-pr): Format commits to include in PR with quote block**
    - Introduce `display_commits_to_include` function to format the list of commits.
    - Present the commits in a visually distinct quote block using `gum format` if available, or fallback to plain echo.
    - Enhance readability and user experience for the `auto_pr.zsh` script output.
- **feat(auto-pr): Use quote block for PR command display**
    - Introduce `display_pr_command` function to format the generated `gh pr create` command.
    - Present the PR command in a visually distinct quote block using `gum format` if available, or fallback to plain echo.
    - Enhance readability and user experience for the `auto_pr.zsh` script output.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)