### PR TITLE
feat(pr-display): Enhance PR display and refactor utilities

### DIFF
--- a/auto_commit.zsh
+++ b/auto_commit.zsh
@@ -78,6 +78,9 @@ source "${script_dir}/utils/commit_message_generator.zsh"
 # Load shared git push helper functions
 source "${script_dir}/utils/git_push_helpers.zsh"
 
+# Load PR display utility
+source "${script_dir}/utils/pr_display.zsh"
+
 # Function to get repository context for LLM
 get_repository_context() {
     local repo_url=$(git remote get-url origin 2>/dev/null)
@@ -211,24 +214,8 @@ except Exception:
                     # Interactive loop for PR update confirmation
                     while true; do
                         
-                        # Display the updated PR content
-                        if command -v gum &> /dev/null; then
-                            echo ""
-                            echo "**Updated PR content:**" | gum format
-                            echo ""
-                            echo "**Title:**" | gum format
-                            echo "$new_title" | gum format -t "code"
-                            echo ""
-                            echo "**Body:**" | gum format
-                            gum style --border=double --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$new_body")"
-                        else
-                            echo ""
-                            echo "Updated PR content:"
-                            echo "Title: $new_title"
-                            echo ""
-                            echo "Body:"
-                            echo "$new_body"
-                        fi
+                        # Display the updated PR content using utility function
+                        display_pr_content "$new_title" "$new_body"
                         
                         local confirm_choice=$(use_gum_choose "Update PR with this content?" "Yes" "Regenerate with feedback" "Skip")
                         

--- a/test/test_pr_display.zsh
+++ b/test/test_pr_display.zsh
@@ -17,30 +17,30 @@ sample_title="feat(auto-commit): Enhance PR update, fix PR number generation, an
 sample_body='## Summary
 
 - Implemented automatic PR update for existing branches, streamlining continuous development workflows.
-- Significantly improved the robustness and accuracy of PR number generation and handling within gh pr edit commands, addressing persistent issues.
+- Significantly improved the robustness and accuracy of PR number generation and handling within `gh pr edit` commands, addressing persistent issues.
 - Enhanced PR content generation by providing the LLM with full context, leading to more comprehensive and relevant titles and bodies.
 - Introduced markdown rendering and display width adjustments for PR body content, improving readability in the terminal.
 - Refactored PR content parsing for increased robustness and streamlined update logic.
 
 ## Recent Changes
 
-- Automatic PR Update: Enhanced auto_commit.zsh to detect unpushed commits on branches with open PRs and provide an interactive flow to update them.
+- Automatic PR Update: Enhanced `auto_commit.zsh` to detect unpushed commits on branches with open PRs and provide an interactive flow to update them.
 - PR Number Fixes:
-  - Introduced PR_NUMBER_PLACEHOLDER and sed replacement to ensure correct PR numbers.
+  - Introduced `PR_NUMBER_PLACEHOLDER` and `sed` replacement to ensure correct PR numbers.
   - Corrected prompt instructions for LLM to use placeholders effectively.
-  - Built gh pr edit command internally from LLM output, ensuring accuracy.
+  - Built `gh pr edit` command internally from LLM output, ensuring accuracy.
   - Added validation and auto-correction for PR numbers in LLM-generated commands.
 - Improved PR Content Generation:
   - Passed all PR commits and existing PR content to the LLM for more context-aware updates.
-  - Delegated full gh pr edit command generation to the LLM for flexibility.
+  - Delegated full `gh pr edit` command generation to the LLM for flexibility.
 - Display Enhancements:
-  - Implemented markdown rendering for PR bodies using gum format.
-  - Correctly nested gum format within gum style for consistent rendering.
-  - Added --width parameter to gum style to adjust PR body display width, preventing overflow.
+  - Implemented markdown rendering for PR bodies using `gum format`.
+  - Correctly nested `gum format` within `gum style` for consistent rendering.
+  - Added `--width` parameter to `gum style` to adjust PR body display width, preventing overflow.
 - Code Refinements:
-  - Replaced jq with a Python script for more robust PR content parsing.
+  - Replaced `jq` with a Python script for more robust PR content parsing.
   - Streamlined PR update logic by merging conditional flows.
-  - Replaced echo with colored_status for consistent and readable output.
+  - Replaced `echo` with `colored_status` for consistent and readable output.
 
 Closes #92
 Refs #106'

--- a/test/test_pr_display.zsh
+++ b/test/test_pr_display.zsh
@@ -14,46 +14,36 @@ echo ""
 # Sample data from user
 sample_title="feat(auto-commit): Enhance PR update, fix PR number generation, and improve display rendering"
 
-sample_body='╔══════════════════════════════════════════════════════════════════════════════════════════════════════════╗
-║                                                                                                          ║
-║    ▌ Summary                                                                                             ║
-║                                                                                                          ║
-║    • Implemented automatic PR update for existing branches, streamlining continuous development          ║
-║  workflows.                                                                                              ║
-║    • Significantly improved the robustness and accuracy of PR number generation and handling within      ║
-║   gh pr edit  commands, addressing persistent issues.                                                    ║
-║    • Enhanced PR content generation by providing the LLM with full context, leading to more              ║
-║  comprehensive and relevant titles and bodies.                                                           ║
-║    • Introduced markdown rendering and display width adjustments for PR body content, improving          ║
-║  readability in the terminal.                                                                            ║
-║    • Refactored PR content parsing for increased robustness and streamlined update logic.                ║
-║                                                                                                          ║
-║    ▌ Recent Changes                                                                                      ║
-║                                                                                                          ║
-║    • Automatic PR Update: Enhanced  auto_commit.zsh  to detect unpushed commits on branches with open    ║
-║  PRs and provide an interactive flow to update them.                                                     ║
-║    • PR Number Fixes:                                                                                    ║
-║      • Introduced  PR_NUMBER_PLACEHOLDER  and  sed  replacement to ensure correct PR numbers.            ║
-║      • Corrected prompt instructions for LLM to use placeholders effectively.                            ║
-║      • Built  gh pr edit  command internally from LLM output, ensuring accuracy.                         ║
-║      • Added validation and auto-correction for PR numbers in LLM-generated commands.                    ║
-║    • Improved PR Content Generation:                                                                     ║
-║      • Passed all PR commits and existing PR content to the LLM for more context-aware updates.          ║
-║      • Delegated full  gh pr edit  command generation to the LLM for flexibility.                        ║
-║    • Display Enhancements:                                                                               ║
-║      • Implemented markdown rendering for PR bodies using  gum format .                                  ║
-║      • Correctly nested  gum format  within  gum style  for consistent rendering.                        ║
-║      • Added  --width  parameter to  gum style  to adjust PR body display width, preventing overflow.    ║
-║    • Code Refinements:                                                                                   ║
-║      • Replaced  jq  with a Python script for more robust PR content parsing.                            ║
-║      • Streamlined PR update logic by merging conditional flows.                                         ║
-║      • Replaced  echo  with  colored_status  for consistent and readable output.                         ║
-║                                                                                                          ║
-║                                                                                                          ║
-║    Closes #92                                                                                            ║
-║    Refs #106                                                                                             ║
-║                                                                                                          ║
-╚══════════════════════════════════════════════════════════════════════════════════════════════════════════╝'
+sample_body='## Summary
+
+- Implemented automatic PR update for existing branches, streamlining continuous development workflows.
+- Significantly improved the robustness and accuracy of PR number generation and handling within gh pr edit commands, addressing persistent issues.
+- Enhanced PR content generation by providing the LLM with full context, leading to more comprehensive and relevant titles and bodies.
+- Introduced markdown rendering and display width adjustments for PR body content, improving readability in the terminal.
+- Refactored PR content parsing for increased robustness and streamlined update logic.
+
+## Recent Changes
+
+- Automatic PR Update: Enhanced auto_commit.zsh to detect unpushed commits on branches with open PRs and provide an interactive flow to update them.
+- PR Number Fixes:
+  - Introduced PR_NUMBER_PLACEHOLDER and sed replacement to ensure correct PR numbers.
+  - Corrected prompt instructions for LLM to use placeholders effectively.
+  - Built gh pr edit command internally from LLM output, ensuring accuracy.
+  - Added validation and auto-correction for PR numbers in LLM-generated commands.
+- Improved PR Content Generation:
+  - Passed all PR commits and existing PR content to the LLM for more context-aware updates.
+  - Delegated full gh pr edit command generation to the LLM for flexibility.
+- Display Enhancements:
+  - Implemented markdown rendering for PR bodies using gum format.
+  - Correctly nested gum format within gum style for consistent rendering.
+  - Added --width parameter to gum style to adjust PR body display width, preventing overflow.
+- Code Refinements:
+  - Replaced jq with a Python script for more robust PR content parsing.
+  - Streamlined PR update logic by merging conditional flows.
+  - Replaced echo with colored_status for consistent and readable output.
+
+Closes #92
+Refs #106'
 
 echo "Testing display_pr_content function..."
 echo ""

--- a/test/test_pr_display.zsh
+++ b/test/test_pr_display.zsh
@@ -1,0 +1,89 @@
+#!/usr/bin/env zsh
+
+# Test script for PR display utility
+# Tests the display_pr_content function with sample data
+
+# Get script directory and source the PR display utility
+script_dir="${0:A:h}/.."
+source "${script_dir}/utils/pr_display.zsh"
+
+echo "🧪 Testing PR Display Utility"
+echo "============================="
+echo ""
+
+# Sample data from user
+sample_title="feat(auto-commit): Enhance PR update, fix PR number generation, and improve display rendering"
+
+sample_body='╔══════════════════════════════════════════════════════════════════════════════════════════════════════════╗
+║                                                                                                          ║
+║    ▌ Summary                                                                                             ║
+║                                                                                                          ║
+║    • Implemented automatic PR update for existing branches, streamlining continuous development          ║
+║  workflows.                                                                                              ║
+║    • Significantly improved the robustness and accuracy of PR number generation and handling within      ║
+║   gh pr edit  commands, addressing persistent issues.                                                    ║
+║    • Enhanced PR content generation by providing the LLM with full context, leading to more              ║
+║  comprehensive and relevant titles and bodies.                                                           ║
+║    • Introduced markdown rendering and display width adjustments for PR body content, improving          ║
+║  readability in the terminal.                                                                            ║
+║    • Refactored PR content parsing for increased robustness and streamlined update logic.                ║
+║                                                                                                          ║
+║    ▌ Recent Changes                                                                                      ║
+║                                                                                                          ║
+║    • Automatic PR Update: Enhanced  auto_commit.zsh  to detect unpushed commits on branches with open    ║
+║  PRs and provide an interactive flow to update them.                                                     ║
+║    • PR Number Fixes:                                                                                    ║
+║      • Introduced  PR_NUMBER_PLACEHOLDER  and  sed  replacement to ensure correct PR numbers.            ║
+║      • Corrected prompt instructions for LLM to use placeholders effectively.                            ║
+║      • Built  gh pr edit  command internally from LLM output, ensuring accuracy.                         ║
+║      • Added validation and auto-correction for PR numbers in LLM-generated commands.                    ║
+║    • Improved PR Content Generation:                                                                     ║
+║      • Passed all PR commits and existing PR content to the LLM for more context-aware updates.          ║
+║      • Delegated full  gh pr edit  command generation to the LLM for flexibility.                        ║
+║    • Display Enhancements:                                                                               ║
+║      • Implemented markdown rendering for PR bodies using  gum format .                                  ║
+║      • Correctly nested  gum format  within  gum style  for consistent rendering.                        ║
+║      • Added  --width  parameter to  gum style  to adjust PR body display width, preventing overflow.    ║
+║    • Code Refinements:                                                                                   ║
+║      • Replaced  jq  with a Python script for more robust PR content parsing.                            ║
+║      • Streamlined PR update logic by merging conditional flows.                                         ║
+║      • Replaced  echo  with  colored_status  for consistent and readable output.                         ║
+║                                                                                                          ║
+║                                                                                                          ║
+║    Closes #92                                                                                            ║
+║    Refs #106                                                                                             ║
+║                                                                                                          ║
+╚══════════════════════════════════════════════════════════════════════════════════════════════════════════╝'
+
+echo "Testing display_pr_content function..."
+echo ""
+
+# Test the function
+display_pr_content "$sample_title" "$sample_body"
+
+echo ""
+echo "✅ Test completed!"
+echo ""
+
+# Test with gum disabled to show fallback behavior
+if command -v gum &> /dev/null; then
+    echo "🔧 Testing fallback mode (simulating gum not available)..."
+    echo ""
+    
+    # Temporarily rename gum to test fallback
+    PATH_BACKUP="$PATH"
+    export PATH=""
+    
+    display_pr_content "$sample_title" "$sample_body"
+    
+    # Restore PATH
+    export PATH="$PATH_BACKUP"
+    
+    echo ""
+    echo "✅ Fallback test completed!"
+else
+    echo "ℹ️  Gum not available - only fallback mode was tested"
+fi
+
+echo ""
+echo "🧪 All tests completed successfully!"

--- a/test/test_pr_display.zsh
+++ b/test/test_pr_display.zsh
@@ -11,6 +11,32 @@ echo "🧪 Testing PR Display Utility"
 echo "============================="
 echo ""
 
+# Test the make_issue_refs_bold function
+echo "Testing make_issue_refs_bold function..."
+echo "----------------------------------------"
+
+test_cases=(
+    "Closes #92"
+    "Refs #106" 
+    "Fixes #123 and resolves #456"
+    "No issue references here"
+    "Multiple #1 #22 #333 #4444 references"
+    "Mixed content with #99 in the middle"
+)
+
+for test_case in "${test_cases[@]}"; do
+    result=$(make_issue_refs_bold "$test_case")
+    echo "Input:  $test_case"
+    echo "Output: $result"
+    echo ""
+done
+
+echo "✅ make_issue_refs_bold tests completed!"
+echo ""
+echo "Testing full PR display..."
+echo "=========================="
+echo ""
+
 # Sample data from user
 sample_title="feat(auto-commit): Enhance PR update, fix PR number generation, and improve display rendering"
 

--- a/utils/pr_display.zsh
+++ b/utils/pr_display.zsh
@@ -5,6 +5,26 @@
 # This utility provides functions for displaying PR content with enhanced formatting
 # using Charmbracelet Gum when available, with graceful fallbacks.
 
+# Function to make issue/PR references bold in text
+# Usage: make_issue_refs_bold "text with #123 references"
+make_issue_refs_bold() {
+    local text="$1"
+    
+    if [ -z "$text" ]; then
+        echo ""
+        return 0
+    fi
+    
+    # Replace #number patterns with **#number** for markdown bold formatting using Python
+    echo "$text" | python3 -c "
+import re
+import sys
+text = sys.stdin.read().rstrip()
+result = re.sub(r'#(\d+)', r'**#\1**', text)
+print(result)
+"
+}
+
 # Function to display PR content with formatted title and body
 # Usage: display_pr_content "title" "body"
 display_pr_content() {
@@ -18,9 +38,10 @@ display_pr_content() {
     
     # Display the updated PR content with gum formatting or fallback
     if command -v gum &> /dev/null; then
+        local enhanced_body=$(make_issue_refs_bold "$body")
         local pr_content=""
         pr_content+="# $title"$'\n'$'\n'
-        pr_content+="$body"
+        pr_content+="$enhanced_body"
 
         gum style --border=normal --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$pr_content")"
     else

--- a/utils/pr_display.zsh
+++ b/utils/pr_display.zsh
@@ -1,0 +1,68 @@
+#!/usr/bin/env zsh
+
+# PR Display Utility
+# 
+# This utility provides functions for displaying PR content with enhanced formatting
+# using Charmbracelet Gum when available, with graceful fallbacks.
+
+# Function to display PR content with formatted title and body
+# Usage: display_pr_content "title" "body"
+display_pr_content() {
+    local title="$1"
+    local body="$2"
+    
+    if [ -z "$title" ] || [ -z "$body" ]; then
+        echo "Error: display_pr_content requires both title and body parameters"
+        return 1
+    fi
+    
+    # Display the updated PR content with gum formatting or fallback
+    if command -v gum &> /dev/null; then
+        echo ""
+        echo "**Updated PR content:**" | gum format
+        echo ""
+        echo "**Title:**" | gum format
+        echo "$title" | gum format -t "code"
+        echo ""
+        echo "**Body:**" | gum format
+        gum style --border=double --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$body")"
+    else
+        echo ""
+        echo "Updated PR content:"
+        echo "Title: $title"
+        echo ""
+        echo "Body:"
+        echo "$body"
+    fi
+}
+
+# Function to display any generic content with title and styled body
+# Usage: display_styled_content "header_text" "title" "body"
+display_styled_content() {
+    local header="$1"
+    local title="$2"
+    local body="$3"
+    
+    if [ -z "$header" ] || [ -z "$title" ] || [ -z "$body" ]; then
+        echo "Error: display_styled_content requires header, title, and body parameters"
+        return 1
+    fi
+    
+    if command -v gum &> /dev/null; then
+        echo ""
+        echo "**$header:**" | gum format
+        echo ""
+        echo "**Title:**" | gum format
+        echo "$title" | gum format -t "code"
+        echo ""
+        echo "**Body:**" | gum format
+        gum style --border=double --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$body")"
+    else
+        echo ""
+        echo "$header:"
+        echo "Title: $title"
+        echo ""
+        echo "Body:"
+        echo "$body"
+    fi
+}

--- a/utils/pr_display.zsh
+++ b/utils/pr_display.zsh
@@ -18,14 +18,11 @@ display_pr_content() {
     
     # Display the updated PR content with gum formatting or fallback
     if command -v gum &> /dev/null; then
-        echo ""
-        echo "**Updated PR content:**" | gum format
-        echo ""
-        echo "**Title:**" | gum format
-        echo "$title" | gum format -t "code"
-        echo ""
-        echo "**Body:**" | gum format
-        gum style --border=double --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$body")"
+        local pr_content=""
+        pr_content+="# $title"$'\n'$'\n'
+        pr_content+="$body"
+
+        gum style --border=double --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$pr_content")"
     else
         echo ""
         echo "Updated PR content:"

--- a/utils/pr_display.zsh
+++ b/utils/pr_display.zsh
@@ -22,7 +22,7 @@ display_pr_content() {
         pr_content+="# $title"$'\n'$'\n'
         pr_content+="$body"
 
-        gum style --border=double --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$pr_content")"
+        gum style --border=normal --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$pr_content")"
     else
         echo ""
         echo "Updated PR content:"


### PR DESCRIPTION
## Summary
This PR enhances the PR display functionality by introducing bold issue references, refining the display border, consolidating title and body into a single box, and improving markdown formatting in test data. It also extracts PR display logic into a dedicated utility for better modularity.

## Changes
- Introduced `make_issue_refs_bold` function to format issue/PR references and applied bold formatting for improved readability.
- Updated `gum style` border from `double` to `normal` in `pr_display.zsh` for cleaner aesthetic.
- Combined PR title and body into a single string for unified display within a single `gum style` bordered box.
- Improved markdown formatting of command names in `test_pr_display.zsh` by using single backticks.
- Simplified PR body sample data in `test_pr_display.zsh` by removing decorative border and updating to cleaner markdown.
- Extracted PR content display logic from `auto_commit.zsh` into `utils/pr_display.zsh`.
- Introduced `display_pr_content` function for consistent PR content rendering with `gum` support and fallback.
- Added `display_styled_content` for generic styled content display.
- Included `test/test_pr_display.zsh` to verify the new utility's functionality and fallback behavior.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)