### PR TITLE
refactor(commit-message-generator): Integrate commit display utility

### DIFF
--- a/test/test_commit_display.zsh
+++ b/test/test_commit_display.zsh
@@ -1,0 +1,35 @@
+#!/usr/bin/env zsh
+
+# Test script for commit message display utility
+
+# Get script directory and source the commit display utility
+script_dir="${0:A:h}/.."
+source "${script_dir}/utils/commit_display.zsh"
+
+echo "🧪 Testing Commit Message Display Utility"
+echo "==========================================="
+echo ""
+
+# Sample commit message based on your example
+sample_commit_message='feat(pr-display): Enhance PR body with bold issue references
+
+- Introduce `make_issue_refs_bold` function to format issue/PR references.
+- Apply bold formatting to issue references within the PR body for improved readability.
+- Add unit tests for the `make_issue_refs_bold` function.
+- Fix issues #123 and resolve #456 for better UX.
+
+🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)'
+
+echo "Testing display_commit_message function..."
+echo "-------------------------------------------"
+display_commit_message "$sample_commit_message"
+
+echo ""
+echo ""
+echo "Testing display_commit_message_with_header function..."
+echo "------------------------------------------------------"
+display_commit_message_with_header "Regenerated commit message" "$sample_commit_message"
+
+echo ""
+echo ""
+echo "✅ All commit display tests completed!"

--- a/test/test_pr_display.zsh
+++ b/test/test_pr_display.zsh
@@ -3,8 +3,9 @@
 # Test script for PR display utility
 # Tests the display_pr_content function with sample data
 
-# Get script directory and source the PR display utility
+# Get script directory and source utilities
 script_dir="${0:A:h}/.."
+source "${script_dir}/utils/text_formatting.zsh"
 source "${script_dir}/utils/pr_display.zsh"
 
 echo "🧪 Testing PR Display Utility"

--- a/utils/commit_display.zsh
+++ b/utils/commit_display.zsh
@@ -5,9 +5,8 @@
 # This utility provides functions for displaying commit messages with enhanced formatting
 # using Charmbracelet Gum when available, with graceful fallbacks.
 
-# Source the PR display utility for shared functions
-script_dir="${0:A:h}"
-source "${script_dir}/pr_display.zsh"
+# Source shared text formatting utility
+source "${script_dir}/utils/text_formatting.zsh"
 
 # Function to display commit message with enhanced formatting
 # Usage: display_commit_message "full_commit_message"

--- a/utils/commit_display.zsh
+++ b/utils/commit_display.zsh
@@ -1,0 +1,81 @@
+#!/usr/bin/env zsh
+
+# Commit Message Display Utility
+# 
+# This utility provides functions for displaying commit messages with enhanced formatting
+# using Charmbracelet Gum when available, with graceful fallbacks.
+
+# Source the PR display utility for shared functions
+script_dir="${0:A:h}"
+source "${script_dir}/pr_display.zsh"
+
+# Function to display commit message with enhanced formatting
+# Usage: display_commit_message "full_commit_message"
+display_commit_message() {
+    local commit_message="$1"
+    
+    if [ -z "$commit_message" ]; then
+        echo "Error: display_commit_message requires a commit message parameter"
+        return 1
+    fi
+    
+    # Parse the commit message to extract title and body
+    local title=$(echo "$commit_message" | head -n 1)
+    local body=$(echo "$commit_message" | tail -n +3)  # Skip title and empty line
+    
+    # Enhance the body with bold issue references
+    local enhanced_body=$(make_issue_refs_bold "$body")
+    
+    # Display with gum formatting or fallback
+    if command -v gum &> /dev/null; then
+        local formatted_content=""
+        formatted_content+="# $title"$'\n'$'\n'
+        formatted_content+="$enhanced_body"
+        
+        echo ""
+        echo "**Generated commit message:**" | gum format
+        gum style --border=normal --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$formatted_content")"
+    else
+        echo ""
+        echo "Generated commit message:"
+        echo "$title"
+        echo ""
+        echo "$enhanced_body"
+    fi
+}
+
+# Function to display commit message with custom header
+# Usage: display_commit_message_with_header "header_text" "full_commit_message"
+display_commit_message_with_header() {
+    local header="$1"
+    local commit_message="$2"
+    
+    if [ -z "$header" ] || [ -z "$commit_message" ]; then
+        echo "Error: display_commit_message_with_header requires header and commit message parameters"
+        return 1
+    fi
+    
+    # Parse the commit message to extract title and body
+    local title=$(echo "$commit_message" | head -n 1)
+    local body=$(echo "$commit_message" | tail -n +3)  # Skip title and empty line
+    
+    # Enhance the body with bold issue references
+    local enhanced_body=$(make_issue_refs_bold "$body")
+    
+    # Display with gum formatting or fallback
+    if command -v gum &> /dev/null; then
+        local formatted_content=""
+        formatted_content+="# $title"$'\n'$'\n'
+        formatted_content+="$enhanced_body"
+        
+        echo ""
+        echo "**$header:**" | gum format
+        gum style --border=normal --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$formatted_content")"
+    else
+        echo ""
+        echo "$header:"
+        echo "$title"
+        echo ""
+        echo "$enhanced_body"
+    fi
+}

--- a/utils/commit_message_generator.zsh
+++ b/utils/commit_message_generator.zsh
@@ -6,6 +6,9 @@
 # Get the script directory to source dependencies
 local util_script_dir="${0:A:h}"
 local gum_helpers_path="${util_script_dir}/../gum/gum_helpers.zsh"
+local commit_display_helpers_path="${util_script_dir}/commit_display.zsh"
+
+source "$commit_display_helpers_path"
 
 # Source gum helper functions for consistent UI
 if [ -f "$gum_helpers_path" ]; then
@@ -85,26 +88,6 @@ display_staged_files() {
         echo "> \n" | gum format
     else
         echo "$staged_files_block"
-    fi
-}
-
-# Function to display commit message in formatted block
-display_commit_message() {
-    local final_commit_msg="$1"
-    
-    # Display generated commit message in quote block format
-    local commit_msg_header="> **Generated commit message:**"
-    local commit_msg_content=$(wrap_quote_block_text "$final_commit_msg")
-    local commit_msg_block="$commit_msg_header"$'\n'"$commit_msg_content"
-    
-    # Display using gum format if available, otherwise fallback to echo
-    if command -v gum &> /dev/null; then
-        echo "$commit_msg_block" | gum format
-        echo "> \\n" | gum format
-    else
-        echo "Generated commit message:"
-        echo "$final_commit_msg"
-        echo ""
     fi
 }
 

--- a/utils/parse_intent.zsh
+++ b/utils/parse_intent.zsh
@@ -20,11 +20,11 @@
 #   SPECIAL_INSTRUCTIONS: [any specific formatting/content requests or NONE]
 
 # Get script directory for utility access
-script_dir="${0:A:h}"
+local_script_dir="${0:A:h}"
 
 # Function to get absolute path to utils directory
 get_utils_path() {
-    echo "${script_dir:A}"
+    echo "${local_script_dir:A}"
 }
 
 # Enhanced intent parsing function

--- a/utils/pr_display.zsh
+++ b/utils/pr_display.zsh
@@ -5,25 +5,8 @@
 # This utility provides functions for displaying PR content with enhanced formatting
 # using Charmbracelet Gum when available, with graceful fallbacks.
 
-# Function to make issue/PR references bold in text
-# Usage: make_issue_refs_bold "text with #123 references"
-make_issue_refs_bold() {
-    local text="$1"
-    
-    if [ -z "$text" ]; then
-        echo ""
-        return 0
-    fi
-    
-    # Replace #number patterns with **#number** for markdown bold formatting using Python
-    echo "$text" | python3 -c "
-import re
-import sys
-text = sys.stdin.read().rstrip()
-result = re.sub(r'#(\d+)', r'**#\1**', text)
-print(result)
-"
-}
+# Source shared text formatting utility
+source "${script_dir}/utils/text_formatting.zsh"
 
 # Function to display PR content with formatted title and body
 # Usage: display_pr_content "title" "body"

--- a/utils/text_formatting.zsh
+++ b/utils/text_formatting.zsh
@@ -1,0 +1,27 @@
+#!/usr/bin/env zsh
+
+# Text Formatting Utility
+# 
+# This utility provides shared text formatting functions for enhancing
+# markdown content across different display utilities.
+
+# Function to make issue/PR references bold in text
+# Usage: make_issue_refs_bold "text with #123 references"
+# Example: "Fixes #123 and closes #456" -> "Fixes **#123** and closes **#456**"
+make_issue_refs_bold() {
+    local text="$1"
+    
+    if [ -z "$text" ]; then
+        echo ""
+        return 0
+    fi
+    
+    # Replace #number patterns with **#number** for markdown bold formatting using Python
+    echo "$text" | python3 -c "
+import re
+import sys
+text = sys.stdin.read().rstrip()
+result = re.sub(r'#(\d+)', r'**#\1**', text)
+print(result)
+"
+}


### PR DESCRIPTION
## Summary
- Integrated commit display utility into commit message generation.
- Extracted shared text formatting functions for reusability.
- Introduced a utility for enhanced commit message display.

## Changes
- Removed duplicated `display_commit_message` function.
- Sourced `commit_display.zsh` to utilize the centralized display utility.
- Moved `make_issue_refs_bold` from `pr_display.zsh` to `utils/text_formatting.zsh`.
- Updated `pr_display.zsh` and `commit_display.zsh` to source the new utility.
- Implemented `display_commit_message` and `display_commit_message_with_header` functions in `utils/commit_display.zsh`.
- Adapted existing PR display logic to format commit messages with `gum` or fallback to plain text.
- Added `test/test_commit_display.zsh` for testing the new utility.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)