### PR TITLE
feat: Implement Issue Display, Refactor Utilities, and Fix Sourcing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,10 @@ Repository context utility for enhanced AI understanding:
 
 Usage: Automatically loaded by main scripts when present
 
+## Development Guidelines
+
+### General Development Notes
+- When making new utilities and files, be aware of pitfalls with pathing and ensure they are symlink compatible
 
 ## Architecture
 

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -131,8 +131,8 @@ if [ $? -eq 0 ] && [ -n "$pr_content_raw" ]; then
         pr_create_command="$pr_content_raw"
 
         # Extract title and body from the generated command
-        local pr_title=$(extract_pr_title "$pr_create_command")
-        local pr_body=$(extract_pr_body "$pr_create_command")
+        local pr_title=$(extract_gh_title "$pr_create_command")
+        local pr_body=$(extract_gh_body "$pr_create_command")
 
         echo ""
         if command -v gum &> /dev/null;then

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -38,6 +38,14 @@ else
     exit 1
 fi
 
+# Load shared command extraction utility
+if [ -f "${script_dir}/utils/gh_command_extraction.zsh" ]; then
+    source "${script_dir}/utils/gh_command_extraction.zsh"
+else
+    echo "Error: Required command extraction utility not found at ${script_dir}/utils/gh_command_extraction.zsh"
+    exit 1
+fi
+
 # Load PR display utility
 if [ -f "${script_dir}/utils/display/pr_display.zsh" ]; then
     source "${script_dir}/utils/display/pr_display.zsh"

--- a/auto_pr.zsh
+++ b/auto_pr.zsh
@@ -145,14 +145,13 @@ if [ $? -eq 0 ] && [ -n "$pr_content_raw" ]; then
         if [ -n "$pr_title" ] && [ -n "$pr_body" ]; then
             display_pr_content "$pr_title" "$pr_body"
         else
-            # Fallback to command display if extraction fails
-            display_styled_content "Generated PR create command" "" "$pr_create_command"
-        fi
-
-        if command -v gum &> /dev/null;then
-            echo "$pr_create_command" | gum format -t "code" -l "zsh"
-        else
-            echo "$pr_create_command"
+            # Fallback: show raw command when extraction fails
+            echo "Generated PR create command:"
+            if command -v gum &> /dev/null; then
+                echo "$pr_create_command" | gum format -t "code" -l "zsh"
+            else
+                echo "$pr_create_command"
+            fi
         fi
 
         response=$(use_gum_choose "Create PR with this command?" "Yes" "Regenerate with feedback" "Quit")

--- a/test/test_issue_display.zsh
+++ b/test/test_issue_display.zsh
@@ -80,17 +80,6 @@ echo ""
 echo "✅ display_issue_content test completed!"
 echo ""
 
-# Test styled content display (fallback scenario when extraction fails)
-sample_raw_command='gh issue create --title "Bug: Login button not working on mobile devices" --body "## Steps to Reproduce\n\n1. Open the application on a mobile device\n2. Navigate to the login page\n3. Enter valid credentials\n4. Tap the Login button\n\n## Expected Behavior\n\nUser should be successfully logged in and redirected to the dashboard.\n\n## Actual Behavior\n\nThe login button does not respond to touch events.\n\n🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)" --label "bug,mobile" --assignee "developer1"'
-
-echo "2. Testing display_styled_content function (fallback for extraction failure)..."
-echo ""
-display_styled_content "Generated Issue Create Command" "" "$sample_raw_command"
-
-echo ""
-echo "✅ display_styled_content fallback test completed!"
-echo ""
-
 # Test with gum disabled to show fallback behavior
 if command -v gum &> /dev/null; then
     echo "🔧 Testing fallback mode (simulating gum not available)..."
@@ -102,10 +91,6 @@ if command -v gum &> /dev/null; then
     
     echo "Fallback: display_issue_content"
     display_issue_content "$sample_title" "$sample_body"
-    echo ""
-    
-    echo "Fallback: display_styled_content"
-    display_styled_content "Generated Issue Create Command" "" "$sample_raw_command"
     echo ""
     
     # Restore PATH

--- a/test/test_issue_display.zsh
+++ b/test/test_issue_display.zsh
@@ -1,0 +1,120 @@
+#!/usr/bin/env zsh
+
+# Test script for Issue display utility
+# Tests all display functions with sample data
+
+# Get script directory and source utilities
+script_dir="${0:A:h}/.."
+source "${script_dir}/utils/text_formatting.zsh"
+source "${script_dir}/utils/display/issue_display.zsh"
+
+echo "🧪 Testing Issue Display Utility"
+echo "================================="
+echo ""
+
+# Test the make_issue_refs_bold function
+echo "Testing make_issue_refs_bold function..."
+echo "----------------------------------------"
+
+test_cases=(
+    "Closes #92"
+    "Refs #106" 
+    "Fixes #123 and resolves #456"
+    "No issue references here"
+    "Multiple #1 #22 #333 #4444 references"
+    "Mixed content with #99 in the middle"
+    "Issue #42 and PR #789 references"
+)
+
+for test_case in "${test_cases[@]}"; do
+    result=$(make_issue_refs_bold "$test_case")
+    echo "Input:  $test_case"
+    echo "Output: $result"
+    echo ""
+done
+
+echo "✅ make_issue_refs_bold tests completed!"
+echo ""
+
+# Sample issue data for testing
+echo "Testing issue display functions..."
+echo "=================================="
+echo ""
+
+sample_title="Bug: Login button not working on mobile devices"
+
+sample_body='## Steps to Reproduce
+
+1. Open the application on a mobile device (tested on iPhone 12, Android Pixel 5)
+2. Navigate to the login page
+3. Enter valid credentials
+4. Tap the "Login" button
+
+## Expected Behavior
+
+User should be successfully logged in and redirected to the dashboard.
+
+## Actual Behavior
+
+The login button does not respond to touch events. No visual feedback is provided when the button is tapped.
+
+## Environment Information
+
+- **Device**: iPhone 12 (iOS 16.1), Android Pixel 5 (Android 13)
+- **Browser**: Safari 16.1, Chrome Mobile 107
+- **App Version**: 2.1.4
+
+## Additional Context
+
+This issue started appearing after the recent UI update in version 2.1.0. Desktop browsers work fine - the issue is specific to mobile devices.
+
+Related to #156 and possibly connected to #89.
+
+🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)'
+
+echo "1. Testing display_issue_content function..."
+echo ""
+display_issue_content "$sample_title" "$sample_body"
+
+echo ""
+echo "✅ display_issue_content test completed!"
+echo ""
+
+# Test styled content display (fallback scenario when extraction fails)
+sample_raw_command='gh issue create --title "Bug: Login button not working on mobile devices" --body "## Steps to Reproduce\n\n1. Open the application on a mobile device\n2. Navigate to the login page\n3. Enter valid credentials\n4. Tap the Login button\n\n## Expected Behavior\n\nUser should be successfully logged in and redirected to the dashboard.\n\n## Actual Behavior\n\nThe login button does not respond to touch events.\n\n🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)" --label "bug,mobile" --assignee "developer1"'
+
+echo "2. Testing display_styled_content function (fallback for extraction failure)..."
+echo ""
+display_styled_content "Generated Issue Create Command" "" "$sample_raw_command"
+
+echo ""
+echo "✅ display_styled_content fallback test completed!"
+echo ""
+
+# Test with gum disabled to show fallback behavior
+if command -v gum &> /dev/null; then
+    echo "🔧 Testing fallback mode (simulating gum not available)..."
+    echo ""
+    
+    # Temporarily rename gum to test fallback
+    PATH_BACKUP="$PATH"
+    export PATH=""
+    
+    echo "Fallback: display_issue_content"
+    display_issue_content "$sample_title" "$sample_body"
+    echo ""
+    
+    echo "Fallback: display_styled_content"
+    display_styled_content "Generated Issue Create Command" "" "$sample_raw_command"
+    echo ""
+    
+    # Restore PATH
+    export PATH="$PATH_BACKUP"
+    
+    echo "✅ Fallback tests completed!"
+else
+    echo "ℹ️  Gum not available - only fallback mode was tested"
+fi
+
+echo ""
+echo "🧪 All issue display tests completed successfully!"

--- a/test/test_pr_regex_extraction.zsh
+++ b/test/test_pr_regex_extraction.zsh
@@ -5,11 +5,8 @@
 # Get script directory
 script_dir="${0:A:h}/.."
 
-# Source the text formatting utility first (required by pr_display.zsh)
-source "${script_dir}/utils/text_formatting.zsh"
-
-# Source the PR display utility to get the extraction function
-source "${script_dir}/utils/display/pr_display.zsh"
+# Source the shared command extraction utility
+source "${script_dir}/utils/gh_command_extraction.zsh"
 
 echo "Testing PR content extraction from gh pr create commands..."
 echo ""
@@ -19,8 +16,8 @@ test_command1='gh pr create --title "Fix login bug" --body "This PR resolves the
 
 echo "Test 1: Simple title and body"
 echo "Command: $test_command1"
-title1=$(extract_pr_title "$test_command1")
-body1=$(extract_pr_body "$test_command1")
+title1=$(extract_gh_title "$test_command1")
+body1=$(extract_gh_body "$test_command1")
 echo "Extracted title: '$title1'"
 echo "Extracted body: '$body1'"
 echo ""
@@ -30,8 +27,8 @@ test_command2='gh pr create --title "Update documentation" --body "This PR updat
 
 echo "Test 2: Multi-line body with issue references"
 echo "Command: $test_command2"
-title2=$(extract_pr_title "$test_command2")
-body2=$(extract_pr_body "$test_command2")
+title2=$(extract_gh_title "$test_command2")
+body2=$(extract_gh_body "$test_command2")
 echo "Extracted title: '$title2'"
 echo "Extracted body:"
 echo "$body2"
@@ -42,8 +39,8 @@ test_command3="gh pr create --title 'Add dark mode feature' --body 'Implements d
 
 echo "Test 3: Single quotes"
 echo "Command: $test_command3"
-title3=$(extract_pr_title "$test_command3")
-body3=$(extract_pr_body "$test_command3")
+title3=$(extract_gh_title "$test_command3")
+body3=$(extract_gh_body "$test_command3")
 echo "Extracted title: '$title3'"
 echo "Extracted body: '$body3'"
 echo ""
@@ -53,8 +50,8 @@ test_command4='gh pr create --title "Refactor user service" --body "This PR refa
 
 echo "Test 4: Complex body with code blocks"
 echo "Command: $test_command4"
-title4=$(extract_pr_title "$test_command4")
-body4=$(extract_pr_body "$test_command4")
+title4=$(extract_gh_title "$test_command4")
+body4=$(extract_gh_body "$test_command4")
 echo "Extracted title: '$title4'"
 echo "Extracted body:"
 echo "$body4"

--- a/utils/README.md
+++ b/utils/README.md
@@ -35,7 +35,7 @@ The Gemini CLI scripts are built on a sophisticated modular architecture that se
 **Key Functions**:
 - `generate_pr_content()` - Creates complete `gh pr create` commands
 - `generate_pr_update_content()` - Handles PR updates with new commits
-- `extract_pr_title()` / `extract_pr_body()` - Parses generated commands
+- Uses shared `extract_gh_title()` / `extract_gh_body()` functions from gh_command_extraction.zsh
 - Automatic issue reference detection and inclusion
 - Context-aware content generation based on commit history
 

--- a/utils/display/issue_display.zsh
+++ b/utils/display/issue_display.zsh
@@ -1,0 +1,69 @@
+#!/usr/bin/env zsh
+
+# Issue Display Utility
+# 
+# This utility provides functions for displaying GitHub issue content with enhanced formatting
+# using Charmbracelet Gum when available, with graceful fallbacks.
+
+# Source shared text formatting utility
+source "${script_dir}/utils/text_formatting.zsh"
+
+# Function to display issue content with formatted title and body
+# Usage: display_issue_content "title" "body"
+display_issue_content() {
+    local title="$1"
+    local body="$2"
+    
+    if [ -z "$title" ] || [ -z "$body" ]; then
+        echo "Error: display_issue_content requires both title and body parameters"
+        return 1
+    fi
+    
+    # Display the issue content with gum formatting or fallback
+    if command -v gum &> /dev/null; then
+        local enhanced_body=$(make_issue_refs_bold "$body")
+        local issue_content=""
+        issue_content+="# $title"$'\n'$'\n'
+        issue_content+="$enhanced_body"
+
+        gum style --border=normal --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$issue_content")"
+    else
+        echo ""
+        echo "Issue content:"
+        echo "Title: $title"
+        echo ""
+        echo "Body:"
+        echo "$body"
+    fi
+}
+
+# Function to display any generic content with title and styled body
+# Usage: display_styled_content "header_text" "title" "body"
+display_styled_content() {
+    local header="$1"
+    local title="$2"
+    local body="$3"
+    
+    if [ -z "$header" ] || [ -z "$title" ] || [ -z "$body" ]; then
+        echo "Error: display_styled_content requires header, title, and body parameters"
+        return 1
+    fi
+    
+    if command -v gum &> /dev/null; then
+        echo ""
+        echo "**$header:**" | gum format
+        echo ""
+        echo "**Title:**" | gum format
+        echo "$title" | gum format -t "code"
+        echo ""
+        echo "**Body:**" | gum format
+        gum style --border=double --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$body")"
+    else
+        echo ""
+        echo "$header:"
+        echo "Title: $title"
+        echo ""
+        echo "Body:"
+        echo "$body"
+    fi
+}

--- a/utils/display/issue_display.zsh
+++ b/utils/display/issue_display.zsh
@@ -37,33 +37,3 @@ display_issue_content() {
     fi
 }
 
-# Function to display any generic content with title and styled body
-# Usage: display_styled_content "header_text" "title" "body"
-display_styled_content() {
-    local header="$1"
-    local title="$2"
-    local body="$3"
-    
-    if [ -z "$header" ] || [ -z "$title" ] || [ -z "$body" ]; then
-        echo "Error: display_styled_content requires header, title, and body parameters"
-        return 1
-    fi
-    
-    if command -v gum &> /dev/null; then
-        echo ""
-        echo "**$header:**" | gum format
-        echo ""
-        echo "**Title:**" | gum format
-        echo "$title" | gum format -t "code"
-        echo ""
-        echo "**Body:**" | gum format
-        gum style --border=double --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$body")"
-    else
-        echo ""
-        echo "$header:"
-        echo "Title: $title"
-        echo ""
-        echo "Body:"
-        echo "$body"
-    fi
-}

--- a/utils/display/pr_display.zsh
+++ b/utils/display/pr_display.zsh
@@ -8,9 +8,6 @@
 # Source shared text formatting utility
 source "${script_dir}/utils/text_formatting.zsh"
 
-# Source shared command extraction utility
-source "${script_dir}/utils/gh_command_extraction.zsh"
-
 # Function to display PR content with formatted title and body
 # Usage: display_pr_content "title" "body"
 display_pr_content() {

--- a/utils/display/pr_display.zsh
+++ b/utils/display/pr_display.zsh
@@ -8,6 +8,9 @@
 # Source shared text formatting utility
 source "${script_dir}/utils/text_formatting.zsh"
 
+# Source shared command extraction utility
+source "${script_dir}/utils/gh_command_extraction.zsh"
+
 # Function to display PR content with formatted title and body
 # Usage: display_pr_content "title" "body"
 display_pr_content() {
@@ -37,47 +40,6 @@ display_pr_content() {
     fi
 }
 
-# Function to extract title from gh pr create command
-# Usage: extract_pr_title "gh pr create --title 'My Title' --body 'My Body'"
-extract_pr_title() {
-    local gh_command="$1"
-    
-    echo "$gh_command" | python3 -c "
-import re
-import sys
-
-command = sys.stdin.read().strip()
-
-# Find --title with quoted content (non-greedy to stop at first closing quote)
-title_match = re.search(r'--title\s+\"(.*?)\"', command, re.DOTALL)
-if not title_match:
-    title_match = re.search(r'--title\s+\'(.*?)\'', command, re.DOTALL)
-
-title = title_match.group(1) if title_match else ''
-print(title)
-"
-}
-
-# Function to extract body from gh pr create command
-# Usage: extract_pr_body "gh pr create --title 'My Title' --body 'My Body'"
-extract_pr_body() {
-    local gh_command="$1"
-    
-    echo "$gh_command" | python3 -c "
-import re
-import sys
-
-command = sys.stdin.read().strip()
-
-# Find --body with quoted content (non-greedy to stop at first closing quote) 
-body_match = re.search(r'--body\s+\"(.*?)\"', command, re.DOTALL)
-if not body_match:
-    body_match = re.search(r'--body\s+\'(.*?)\'', command, re.DOTALL)
-
-body = body_match.group(1) if body_match else ''
-print(body)
-"
-}
 
 # Function to display any generic content with title and styled body
 # Usage: display_styled_content "header_text" "title" "body"

--- a/utils/display/pr_display.zsh
+++ b/utils/display/pr_display.zsh
@@ -38,33 +38,3 @@ display_pr_content() {
 }
 
 
-# Function to display any generic content with title and styled body
-# Usage: display_styled_content "header_text" "title" "body"
-display_styled_content() {
-    local header="$1"
-    local title="$2"
-    local body="$3"
-    
-    if [ -z "$header" ] || [ -z "$title" ] || [ -z "$body" ]; then
-        echo "Error: display_styled_content requires header, title, and body parameters"
-        return 1
-    fi
-    
-    if command -v gum &> /dev/null; then
-        echo ""
-        echo "**$header:**" | gum format
-        echo ""
-        echo "**Title:**" | gum format
-        echo "$title" | gum format -t "code"
-        echo ""
-        echo "**Body:**" | gum format
-        gum style --border=double --padding="1 2" --width=$((COLUMNS - 6)) "$(gum format "$body")"
-    else
-        echo ""
-        echo "$header:"
-        echo "Title: $title"
-        echo ""
-        echo "Body:"
-        echo "$body"
-    fi
-}

--- a/utils/gh_command_extraction.zsh
+++ b/utils/gh_command_extraction.zsh
@@ -1,0 +1,50 @@
+#!/usr/bin/env zsh
+
+# GitHub Command Extraction Utility
+# 
+# This utility provides shared functions for extracting title and body parameters
+# from GitHub CLI commands (gh pr create, gh issue create, etc.)
+
+# Function to extract title from gh create commands
+# Usage: extract_gh_title "gh pr create --title 'My Title' --body 'My Body'"
+# Usage: extract_gh_title "gh issue create --title 'My Title' --body 'My Body'"
+extract_gh_title() {
+    local gh_command="$1"
+    
+    echo "$gh_command" | python3 -c "
+import re
+import sys
+
+command = sys.stdin.read().strip()
+
+# Find --title with quoted content (non-greedy to stop at first closing quote)
+title_match = re.search(r'--title\s+\"(.*?)\"', command, re.DOTALL)
+if not title_match:
+    title_match = re.search(r'--title\s+\'(.*?)\'', command, re.DOTALL)
+
+title = title_match.group(1) if title_match else ''
+print(title)
+"
+}
+
+# Function to extract body from gh create commands
+# Usage: extract_gh_body "gh pr create --title 'My Title' --body 'My Body'"
+# Usage: extract_gh_body "gh issue create --title 'My Title' --body 'My Body'"
+extract_gh_body() {
+    local gh_command="$1"
+    
+    echo "$gh_command" | python3 -c "
+import re
+import sys
+
+command = sys.stdin.read().strip()
+
+# Find --body with quoted content (non-greedy to stop at first closing quote) 
+body_match = re.search(r'--body\s+\"(.*?)\"', command, re.DOTALL)
+if not body_match:
+    body_match = re.search(r'--body\s+\'(.*?)\'', command, re.DOTALL)
+
+body = body_match.group(1) if body_match else ''
+print(body)
+"
+}


### PR DESCRIPTION
## Summary
- Implemented a new utility for formatted display of GitHub issue content.
- Refactored and simplified existing display logic for both PRs and issues.
- Extracted common GitHub CLI command parsing functions into a shared utility.
- Fixed a critical issue where new utility functions were not being correctly sourced.

## Recent Changes
- **fix(auto_pr): Correctly source gh_command_extraction utility**
  - Added missing `source` command for `utils/gh_command_extraction.zsh` in `auto_pr.zsh`.
  - Resolves an issue where the utility functions were not properly loaded after the refactor.
- **refactor(display): Remove redundant `display_styled_content` function**
  - Removed the `display_styled_content` function from `utils/display/issue_display.zsh` and `utils/display/pr_display.zsh`.
  - Updated `auto_pr.zsh` to directly display the raw command as a fallback, eliminating the need for the removed function.
  - Removed corresponding tests from `test/test_issue_display.zsh`.
- **feat(issue_display): Implement basic issue display utility**
  - Introduces `utils/display/issue_display.zsh` for formatted display of GitHub issue content.
  - Adds `display_issue_content` and `display_styled_content` functions, providing a twin to existing PR display functionality.
  - Includes `test/test_issue_display.zsh` for comprehensive testing of the new utility.
- **refactor(pr_display): Remove redundant gh_command_extraction import**
  - The `gh_command_extraction.zsh` import is no longer needed in `pr_display.zsh` as its functions were moved out in a previous refactor.
- **refactor: Extract gh command parsing to shared utility**
  - Moved `extract_pr_title` and `extract_pr_body` from `utils/display/pr_display.zsh` to a new shared utility `utils/gh_command_extraction.zsh`.
  - Renamed functions to `extract_gh_title` and `extract_gh_body` to reflect their broader applicability across GitHub CLI commands.
  - Updated `auto_pr.zsh` and `test/test_pr_regex_extraction.zsh` to use the new shared functions.
  - Ensured `utils/README.md` reflects the change.

Closes #120