### PR TITLE
feat(auto_commit): Add --no-branch flag for direct commits

### DIFF
--- a/.gemini-config
+++ b/.gemini-config
@@ -25,7 +25,7 @@ AUTO_STAGE=true
 AUTO_PR=false
 
 # Automatically create new branch without confirmation (equivalent to --branch flag)
-AUTO_BRANCH=true
+AUTO_BRANCH=false
 
 # Automatically push changes after successful commit (equivalent to --push flag)
 AUTO_PUSH=false


### PR DESCRIPTION
## Summary
- Introduces a new `--no-branch` option to `auto_commit.zsh` to allow committing directly to the current branch, bypassing automatic branch creation.

## Changes
- Adds validation to prevent simultaneous use of `--no-branch` and `-b/--branch` flags.
- Updates the default `AUTO_BRANCH` setting in `.gemini-config` to `false` to align with the new flexibility.
- Implements specific logic for handling staging and confirmation when `--no-branch` is used on `main` or `master` branches.

fixes #133

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)