### PR TITLE
feat(auto_commit): Allow adding comments to PR generation

### DIFF
--- a/auto_commit.zsh
+++ b/auto_commit.zsh
@@ -709,9 +709,28 @@ if ! git diff --cached --quiet; then
                                         "${script_dir}/auto_pr.zsh" "$1"
                                     else
                                         echo ""
-                                        if use_gum_confirm "Create a pull request?"; then
-                                            "${script_dir}/auto_pr.zsh" "$1"
-                                        fi
+                                        pr_choice=$(use_gum_choose "Create a pull request?" "Yes" "Yes with comment" "No")
+                                        case "$pr_choice" in
+                                            "Yes" )
+                                                "${script_dir}/auto_pr.zsh" "$1"
+                                                ;;
+                                            "Yes with comment" )
+                                                pr_comment=$(use_gum_input "Enter additional context for PR generation:" "Additional context or requirements")
+                                                # Combine original context with new comment
+                                                combined_context="$1"
+                                                if [ -n "$pr_comment" ]; then
+                                                    if [ -n "$combined_context" ]; then
+                                                        combined_context="$combined_context. $pr_comment"
+                                                    else
+                                                        combined_context="$pr_comment"
+                                                    fi
+                                                fi
+                                                "${script_dir}/auto_pr.zsh" "$combined_context"
+                                                ;;
+                                            "No"|* )
+                                                # Do nothing - no PR creation
+                                                ;;
+                                        esac
                                     fi
                                     ;;
                             esac


### PR DESCRIPTION
## Summary
- Implemented a feature to allow users to add comments during PR generation.

## Changes
- Replaced `gum confirm` with `gum choose` for the PR creation prompt.
- Added a "Yes with comment" option to enable providing additional context for the PR.
- Combined user-provided comments with the original PR context before calling `auto_pr.zsh`.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)