### PR TITLE
feat(auto-commit): Add --dry-run option for simulated execution

### DIFF
--- a/utils/git/git_push_helpers.zsh
+++ b/utils/git/git_push_helpers.zsh
@@ -34,54 +34,99 @@ display_push_result() {
 }
 
 # Function to intelligently select and execute git push command
-# Usage: smart_git_push "$branch_name"
+# Usage: smart_git_push "$branch_name" "$dry_run"
 # Returns results in global variables: PUSH_OUTPUT, PUSH_EXIT_CODE, PUSH_COMMAND
 smart_git_push() {
     local branch_name="$1"
+    local dry_run="${2:-false}"
     
     # Check if upstream branch is set
     if git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
         # Upstream is set, a simple push is enough
         PUSH_COMMAND="git push"
-        PUSH_OUTPUT=$(git push 2>&1)
-        PUSH_EXIT_CODE=$?
+        if [ "$dry_run" = true ]; then
+            colored_status "🔍 DRY RUN: Would execute push" "info" >&2
+            if command -v gum &> /dev/null; then
+                echo "  ⎿ Command:" >&2
+                echo "$PUSH_COMMAND" | gum format -t "code" -l "zsh" >&2
+            else
+                echo "  ⎿ Command: $PUSH_COMMAND" >&2
+            fi
+            PUSH_OUTPUT="To github.com:user/repo.git
+   abc1234..def5678  $branch_name -> $branch_name"
+            PUSH_EXIT_CODE=0
+        else
+            PUSH_OUTPUT=$(git push 2>&1)
+            PUSH_EXIT_CODE=$?
+        fi
     else
         # Upstream is not set, so we need to publish the branch
         colored_status "No upstream branch found for '$branch_name'" "info"
         echo "  ⎿ Publishing to 'origin/$branch_name'..."
         PUSH_COMMAND="git push --set-upstream origin \"$branch_name\""
-        PUSH_OUTPUT=$(git push --set-upstream origin "$branch_name" 2>&1)
-        PUSH_EXIT_CODE=$?
+        if [ "$dry_run" = true ]; then
+            colored_status "🔍 DRY RUN: Would execute push with upstream" "info" >&2
+            if command -v gum &> /dev/null; then
+                echo "  ⎿ Command:" >&2
+                echo "git push --set-upstream origin '$branch_name'" | gum format -t "code" -l "zsh" >&2
+            else
+                echo "  ⎿ Command: git push --set-upstream origin '$branch_name'" >&2
+            fi
+            PUSH_OUTPUT="To github.com:user/repo.git
+ * [new branch]      $branch_name -> $branch_name
+Branch '$branch_name' set up to track remote branch '$branch_name' from 'origin'."
+            PUSH_EXIT_CODE=0
+        else
+            PUSH_OUTPUT=$(git push --set-upstream origin "$branch_name" 2>&1)
+            PUSH_EXIT_CODE=$?
+        fi
     fi
 }
 
 # Function to execute git push with upstream setup (always sets upstream)
-# Usage: force_upstream_push "$branch_name"
+# Usage: force_upstream_push "$branch_name" "$dry_run"
 # Returns results in global variables: PUSH_OUTPUT, PUSH_EXIT_CODE, PUSH_COMMAND
 force_upstream_push() {
     local branch_name="$1"
+    local dry_run="${2:-false}"
     
     PUSH_COMMAND="git push -u origin \"$branch_name\""
-    PUSH_OUTPUT=$(git push -u origin "$branch_name" 2>&1)
-    PUSH_EXIT_CODE=$?
+    if [ "$dry_run" = true ]; then
+        colored_status "🔍 DRY RUN: Would execute push with forced upstream" "info" >&2
+        if command -v gum &> /dev/null; then
+            echo "  ⎿ Command:" >&2
+            echo "git push -u origin '$branch_name'" | gum format -t "code" -l "zsh" >&2
+        else
+            echo "  ⎿ Command: git push -u origin '$branch_name'" >&2
+        fi
+        PUSH_OUTPUT="To github.com:user/repo.git
+ * [new branch]      $branch_name -> $branch_name
+Branch '$branch_name' set up to track remote branch '$branch_name' from 'origin'."
+        PUSH_EXIT_CODE=0
+    else
+        PUSH_OUTPUT=$(git push -u origin "$branch_name" 2>&1)
+        PUSH_EXIT_CODE=$?
+    fi
 }
 
 # High-level function combining push execution and display
-# Usage: execute_push_with_display "$branch_name" "$push_mode" "$on_failure"
+# Usage: execute_push_with_display "$branch_name" "$push_mode" "$on_failure" "$dry_run"
 # push_mode: "smart" (detect upstream) | "force-upstream" (always set upstream)
 # on_failure: "continue" | "exit" | "break" | "return"
+# dry_run: "true" | "false"
 execute_push_with_display() {
     local branch_name="$1"
     local push_mode="${2:-smart}"
     local on_failure="${3:-continue}"
+    local dry_run="${4:-false}"
     
     # Execute the appropriate push command
     case "$push_mode" in
         "smart")
-            smart_git_push "$branch_name"
+            smart_git_push "$branch_name" "$dry_run"
             ;;
         "force-upstream")
-            force_upstream_push "$branch_name"
+            force_upstream_push "$branch_name" "$dry_run"
             ;;
         *)
             echo "Error: Unknown push mode '$push_mode'. Use 'smart' or 'force-upstream'."
@@ -124,15 +169,17 @@ execute_push_with_display() {
 }
 
 # Convenience function for simple push with display (most common case)
-# Usage: simple_push_with_display "$branch_name"
+# Usage: simple_push_with_display "$branch_name" "$dry_run"
 simple_push_with_display() {
     local branch_name="$1"
-    execute_push_with_display "$branch_name" "smart" "return"
+    local dry_run="${2:-false}"
+    execute_push_with_display "$branch_name" "smart" "return" "$dry_run"
 }
 
 # Convenience function for PR-style push with display (always set upstream)
-# Usage: pr_push_with_display "$branch_name"
+# Usage: pr_push_with_display "$branch_name" "$dry_run"
 pr_push_with_display() {
     local branch_name="$1"
-    execute_push_with_display "$branch_name" "force-upstream" "return"
+    local dry_run="${2:-false}"
+    execute_push_with_display "$branch_name" "force-upstream" "return" "$dry_run"
 }


### PR DESCRIPTION
## Summary
- Introduce `--dry-run` flag to `auto_commit.zsh` for simulated command execution.

## Changes
- Integrate dry-run logic into `git add`, `git switch`, `git commit`, and `auto_pr.zsh` calls within `auto_commit.zsh`.
- Extend `git_push_helpers.zsh` functions to support dry-run mode, simulating `git push` commands.
- Provide clear dry-run output using `colored_status` and `gum format` for simulated commands.

contributes to #87

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)