### PR TITLE
feat(auto-issue): Implement --dry-run mode for simulated execution

### DIFF
--- a/gum/gum_helpers.zsh
+++ b/gum/gum_helpers.zsh
@@ -119,9 +119,33 @@ use_gum_choose() {
 }
 
 use_gum_input() {
+    local dry_run=false
+    
+    # Check if first argument is dry-run flag
+    if [[ "$1" =~ ^--dry-run= ]]; then
+        local dry_run_value="${1#--dry-run=}"
+        [[ "$dry_run_value" == "true" ]] && dry_run=true
+        shift  # Remove the flag
+    fi
+    
     local prompt="$1"
     local placeholder="${2:-}"
     local default_value="${3:-}"
+    
+    # Dry-run behavior - return placeholder or default content
+    if [ "$dry_run" = true ]; then
+        local content=""
+        if [ -n "$default_value" ]; then
+            content="$default_value"
+        elif [ -n "$placeholder" ]; then
+            content="$placeholder"
+        else
+            content="dry-run-input"
+        fi
+        colored_status "🔍 DRY RUN: Auto-providing input for: $prompt" "info" >&2
+        echo "$content"
+        return 0
+    fi
     
     if command -v gum &> /dev/null; then
         local result
@@ -159,9 +183,33 @@ use_gum_input() {
 }
 
 use_gum_write() {
+    local dry_run=false
+    
+    # Check if first argument is dry-run flag
+    if [[ "$1" =~ ^--dry-run= ]]; then
+        local dry_run_value="${1#--dry-run=}"
+        [[ "$dry_run_value" == "true" ]] && dry_run=true
+        shift  # Remove the flag
+    fi
+    
     local prompt="$1"
     local placeholder="${2:-}"
     local default_value="${3:-}"
+    
+    # Dry-run behavior - return placeholder or default content
+    if [ "$dry_run" = true ]; then
+        local content=""
+        if [ -n "$default_value" ]; then
+            content="$default_value"
+        elif [ -n "$placeholder" ]; then
+            content="$placeholder"
+        else
+            content="Sample content for dry-run mode. This would be user-entered text."
+        fi
+        colored_status "🔍 DRY RUN: Auto-providing content for: $prompt" "info" >&2
+        echo "$content"
+        return 0
+    fi
     
     if command -v gum &> /dev/null; then
         local result


### PR DESCRIPTION
## Summary
- Implemented `--dry-run` mode for `auto_issue.zsh` to simulate GitHub issue operations.

## Changes
- Extended `--dry-run` functionality to `auto_issue.zsh`.
- Integrated `dry_run` flag into `gum_helpers.zsh` (`use_gum_input`, `use_gum_write`) for simulated user input.
- Added dry-run logic to LLM-powered content generation functions (`_edit_generate_content`, `_comment_generate_content`, `create_issue_with_llm`) to simulate Gemini CLI output.
- Ensured consistent passing and respect of the `dry_run` flag across relevant functions within `auto_issue.zsh`.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)