### PR TITLE
Refactor(orchestrator): Split application into internal modules

### DIFF
--- a/orchestrator/internal/commands/handler.go
+++ b/orchestrator/internal/commands/handler.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"strings"
+
+	"gemini-orchestrator/internal/models"
+	"gemini-orchestrator/internal/ui"
+	"gemini-orchestrator/internal/utils"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func HandleCommand(inputValue string, m *models.Model) tea.Cmd {
+	// Handle /reload command
+	if inputValue == "/reload" {
+		// Start building process
+		m.IsBuilding = true
+		m.TextInput.SetValue("")
+		m.ShowSuggestions = false
+		m.ShowHelp = false
+		return tea.Batch(m.Spinner.Tick, utils.BuildAndReloadCmd())
+	}
+
+	// Handle /commit command
+	if strings.HasPrefix(inputValue, "/commit") {
+		m.Messages = append(m.Messages, "⚠️ /commit command not yet implemented")
+		resetInput(m)
+		return nil
+	}
+
+	// Handle /pr command
+	if strings.HasPrefix(inputValue, "/pr") {
+		m.Messages = append(m.Messages, "⚠️ /pr command not yet implemented")
+		resetInput(m)
+		return nil
+	}
+
+	// Handle /issue command
+	if inputValue == "/issue" {
+		m.Messages = append(m.Messages, "⚠️ /issue command not yet implemented")
+		resetInput(m)
+		return nil
+	}
+
+	// Handle /clear command
+	if inputValue == "/clear" {
+		// Clear entire display and reset to initial state
+		ui.ComposeUI(m)
+		m.Messages = []string{"Display cleared."}
+		resetInput(m)
+		return nil
+	}
+
+	// Default: add message to history
+	m.Messages = append(m.Messages, m.TextInput.Value())
+	resetInput(m)
+	return nil
+}
+
+func resetInput(m *models.Model) {
+	m.TextInput.SetValue("")
+	m.ShowSuggestions = false
+	m.ShowHelp = false
+}

--- a/orchestrator/internal/models/app.go
+++ b/orchestrator/internal/models/app.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"github.com/charmbracelet/bubbles/cursor"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/lipgloss"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type Model struct {
+	TextInput          textinput.Model
+	Messages           []string
+	Suggestions        []string
+	SelectedSuggestion int
+	ShowSuggestions    bool
+	ShowHelp           bool
+	Width              int
+	Height             int
+	Spinner            spinner.Model
+	IsBuilding         bool
+	ShowExitConfirm    bool
+}
+
+func InitialModel() Model {
+	ti := textinput.New()
+	ti.Placeholder = "Type your message..."
+	ti.Focus()
+	ti.CharLimit = 200
+	ti.Width = 50
+	ti.Cursor.SetMode(cursor.CursorStatic)
+
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+
+	return Model{
+		TextInput:          ti,
+		Messages:           []string{},
+		Suggestions:        []string{},
+		SelectedSuggestion: 0,
+		ShowSuggestions:    false,
+		ShowHelp:           false,
+		Width:              80,
+		Height:             24,
+		Spinner:            s,
+		IsBuilding:         false,
+		ShowExitConfirm:    false,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/orchestrator/internal/models/messages.go
+++ b/orchestrator/internal/models/messages.go
@@ -1,0 +1,36 @@
+package models
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type BuildCompleteMsg struct{}
+type BuildErrorMsg struct{ Err error }
+type ShutdownMsg struct{ Signal os.Signal }
+type CtrlCTimeoutMsg struct{}
+
+func CtrlCTimeoutCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg {
+		return CtrlCTimeoutMsg{}
+	})
+}
+
+func ListenForSignals() tea.Cmd {
+	return func() tea.Msg {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan,
+			syscall.SIGINT,  // Ctrl+C
+			syscall.SIGTERM, // Termination request
+			syscall.SIGHUP,  // Terminal disconnection
+			syscall.SIGQUIT, // Quit signal
+		)
+
+		sig := <-sigChan
+		return ShutdownMsg{Signal: sig}
+	}
+}

--- a/orchestrator/internal/models/suggestions.go
+++ b/orchestrator/internal/models/suggestions.go
@@ -1,0 +1,39 @@
+package models
+
+import "strings"
+
+var SlashCommands = []string{
+	"/commit",
+	"/pr",
+	"/issue",
+	"/help",
+	"/clear",
+	"/reload",
+}
+
+func (m *Model) UpdateSuggestions() {
+	input := m.TextInput.Value()
+
+	if strings.HasPrefix(input, "/") {
+		m.ShowHelp = false
+		oldSuggestions := m.Suggestions
+		m.Suggestions = []string{}
+		for _, cmd := range SlashCommands {
+			if strings.HasPrefix(cmd, input) {
+				m.Suggestions = append(m.Suggestions, cmd)
+			}
+		}
+		m.ShowSuggestions = len(m.Suggestions) > 0
+
+		// Only reset selection if suggestions changed or if we had no suggestions before
+		if len(oldSuggestions) == 0 || !slicesEqual(oldSuggestions, m.Suggestions) {
+			m.SelectedSuggestion = 0
+		} else if m.SelectedSuggestion >= len(m.Suggestions) {
+			// Clamp selection if it's out of bounds
+			m.SelectedSuggestion = len(m.Suggestions) - 1
+		}
+	} else {
+		m.ShowSuggestions = false
+		m.Suggestions = []string{}
+	}
+}

--- a/orchestrator/internal/ui/render.go
+++ b/orchestrator/internal/ui/render.go
@@ -1,0 +1,97 @@
+package ui
+
+import (
+	"fmt"
+
+	"gemini-orchestrator/internal/models"
+)
+
+func RenderHeader() string {
+	return TitleStyle.Render("Gemini CLI Orchestrator") + "\n\n"
+}
+
+func RenderContent(m models.Model) string {
+	var content string
+
+	// Messages history
+	if len(m.Messages) > 0 {
+		for _, msg := range m.Messages {
+			content += MessageStyle.Render(fmt.Sprintf("> %s", msg)) + "\n"
+		}
+		content += "\n"
+	}
+
+	return content
+}
+
+func RenderInputBar(m models.Model) string {
+	var inputBar string
+
+	// Only show input if not building
+	if !m.IsBuilding {
+		// Input with full-width border
+		inputBox := InputBoxStyle.Width(m.Width - 2) // Full width minus small margin
+		inputBar += inputBox.Render(m.TextInput.View())
+	}
+
+	return inputBar
+}
+
+func RenderView(m models.Model) string {
+	var view string
+
+	// Composable UI layout
+	view += RenderHeader()
+	view += RenderContent(m)
+
+	// Show building spinner if building
+	if m.IsBuilding {
+		view += SuggestionStyle.Render(fmt.Sprintf("%s Building and reloading...", m.Spinner.View())) + "\n\n"
+	}
+
+	view += RenderInputBar(m)
+
+	// Only show UI elements if not building
+	if !m.IsBuilding {
+		if m.ShowExitConfirm {
+			// Priority 1: Exit confirmation (overrides everything else)
+			view += HelpTextStyle.Render("Press Ctrl+C again to exit (or Esc to cancel)")
+		} else if m.ShowSuggestions && len(m.Suggestions) > 0 {
+			// Priority 2: Suggestions dropdown
+			view += "\n"
+			for i, suggestion := range m.Suggestions {
+				if i == m.SelectedSuggestion {
+					view += SelectedSuggestionStyle.Render(suggestion) + "\n"
+				} else {
+					view += SuggestionStyle.Render(suggestion) + "\n"
+				}
+			}
+			view += "\n"
+			view += BlurredStyle.Render("↑/↓ to navigate • Tab to complete • Enter to execute")
+		} else if m.ShowHelp {
+			// Priority 3: Help shortcuts
+			view += "\n"
+			formattedShortcuts := DistributeShortcuts(m.Width)
+			for _, shortcut := range formattedShortcuts {
+				view += SuggestionStyle.Render(shortcut) + "\n"
+			}
+		} else {
+			// Priority 4: Default help prompt
+			view += HelpTextStyle.Render("? for shortcuts")
+		}
+	}
+
+	view += "\n"
+	view += "\n"
+
+	return view
+}
+
+func ClearConsole() {
+	fmt.Print("\033[2J\033[H")
+}
+
+func ComposeUI(m *models.Model) {
+	// Reset UI state - Bubble Tea will handle the visual refresh automatically
+	// This is the recommended approach rather than direct console manipulation
+}

--- a/orchestrator/internal/ui/shortcuts.go
+++ b/orchestrator/internal/ui/shortcuts.go
@@ -1,0 +1,169 @@
+package ui
+
+import "strings"
+
+var ModeShortcuts = []string{
+	"! for bash mode",
+	"/ for commands",
+	"@ for file paths",
+	"# to memorize",
+}
+
+var GeneralShortcuts = []string{
+	"double tap esc to clear input",
+	"shift + tab to auto-accept edits",
+	"ctrl + r for verbose output",
+	"shift + e for newline",
+	"ctrl + _ to undo",
+	"ctrl + z to suspend",
+}
+
+func DistributeShortcuts(terminalWidth int) []string {
+	// Try 3 columns first (modes + general shortcuts with different spacing)
+	formatted := tryThreeColumnLayout(terminalWidth)
+	if formatted != nil {
+		return formatted
+	}
+
+	// Fallback to 2 columns (modes | all general shortcuts)
+	formatted = tryTwoColumnLayout(terminalWidth)
+	if formatted != nil {
+		return formatted
+	}
+
+	// Fallback to 1 column (everything stacked)
+	return tryOneColumnLayout()
+}
+
+func tryThreeColumnLayout(terminalWidth int) []string {
+	// Mode shortcuts in column 1, general shortcuts distributed in columns 2&3
+	maxRows := len(ModeShortcuts)
+	generalPerCol := (len(GeneralShortcuts) + 1) / 2 // Split general shortcuts across 2 columns
+	if generalPerCol > maxRows {
+		maxRows = generalPerCol
+	}
+
+	// Create grid
+	grid := make([][]string, maxRows)
+	for i := range grid {
+		grid[i] = make([]string, 3)
+	}
+
+	// Fill column 1 with mode shortcuts
+	for i, shortcut := range ModeShortcuts {
+		grid[i][0] = shortcut
+	}
+
+	// Fill columns 2&3 with general shortcuts
+	for i, shortcut := range GeneralShortcuts {
+		col := 1 + (i / generalPerCol)
+		row := i % generalPerCol
+		if col < 3 && row < maxRows {
+			grid[row][col] = shortcut
+		}
+	}
+
+	// Calculate widths: mode column uses 8 spaces, general columns use 4 spaces
+	maxWidths := make([]int, 3)
+	for _, row := range grid {
+		for i, cell := range row {
+			if len(cell) > maxWidths[i] {
+				maxWidths[i] = len(cell)
+			}
+		}
+	}
+
+	// Calculate total width with mixed spacing
+	totalWidth := maxWidths[0] + 8 + maxWidths[1] + 4 + maxWidths[2]
+	if totalWidth > terminalWidth-10 {
+		return nil // Doesn't fit
+	}
+
+	// Format with mixed spacing
+	var formatted []string
+	for _, row := range grid {
+		var line string
+		for i, cell := range row {
+			if i == 0 {
+				line = cell
+			} else if cell != "" {
+				spacing := 8 // Default to 8 spaces
+				if i == 2 {
+					spacing = 4 // 4 spaces between general columns
+				}
+				padding := maxWidths[i-1] - len(row[i-1]) + spacing
+				line += strings.Repeat(" ", padding) + cell
+			}
+		}
+		if strings.TrimSpace(line) != "" {
+			formatted = append(formatted, line)
+		}
+	}
+
+	return formatted
+}
+
+func tryTwoColumnLayout(terminalWidth int) []string {
+	// Mode shortcuts in column 1, all general shortcuts in column 2
+	maxRows := len(ModeShortcuts)
+	if len(GeneralShortcuts) > maxRows {
+		maxRows = len(GeneralShortcuts)
+	}
+
+	// Create grid
+	grid := make([][]string, maxRows)
+	for i := range grid {
+		grid[i] = make([]string, 2)
+	}
+
+	// Fill columns
+	for i, shortcut := range ModeShortcuts {
+		grid[i][0] = shortcut
+	}
+	for i, shortcut := range GeneralShortcuts {
+		grid[i][1] = shortcut
+	}
+
+	// Calculate widths
+	maxWidths := make([]int, 2)
+	for _, row := range grid {
+		for i, cell := range row {
+			if len(cell) > maxWidths[i] {
+				maxWidths[i] = len(cell)
+			}
+		}
+	}
+
+	// Check if it fits
+	totalWidth := maxWidths[0] + 8 + maxWidths[1]
+	if totalWidth > terminalWidth-10 {
+		return nil
+	}
+
+	// Format
+	var formatted []string
+	for _, row := range grid {
+		var line string
+		for i, cell := range row {
+			if i == 0 {
+				line = cell
+			} else if cell != "" {
+				padding := maxWidths[i-1] - len(row[i-1]) + 8
+				line += strings.Repeat(" ", padding) + cell
+			}
+		}
+		if strings.TrimSpace(line) != "" {
+			formatted = append(formatted, line)
+		}
+	}
+
+	return formatted
+}
+
+func tryOneColumnLayout() []string {
+	// Stack everything in one column
+	var formatted []string
+	formatted = append(formatted, ModeShortcuts...)
+	formatted = append(formatted, GeneralShortcuts...)
+	return formatted
+}

--- a/orchestrator/internal/ui/styles.go
+++ b/orchestrator/internal/ui/styles.go
@@ -1,0 +1,33 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	FocusedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+	BlurredStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	TitleStyle   = lipgloss.NewStyle().
+			Background(lipgloss.Color("62")).
+			Foreground(lipgloss.Color("230")).
+			Padding(0, 1).
+			MarginBottom(1)
+	SuggestionStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#CBC8C6")).
+			Padding(0, 2)
+	SelectedSuggestionStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#4E5EDE")).
+				Padding(0, 2)
+	InputBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#CBC8C6")).
+			Padding(0, 1)
+	HelpTextStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#CBC8C6")).
+			MarginTop(1).
+			Padding(0, 2)
+	MessageStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#CBC8C6"))
+)
+
+func InitSpinnerStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+}

--- a/orchestrator/internal/utils/build.go
+++ b/orchestrator/internal/utils/build.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"gemini-orchestrator/internal/models"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func BuildAndReloadCmd() tea.Cmd {
+	return func() tea.Msg {
+		// Get the current executable path
+		execPath, err := os.Executable()
+		if err != nil {
+			return models.BuildErrorMsg{Err: fmt.Errorf("failed to get executable path: %w", err)}
+		}
+
+		// Get the source directory (where main.go is located)
+		// This handles symlinks by getting the directory of the actual binary
+		sourceDir := execPath
+		if info, err := os.Lstat(execPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			// It's a symlink, resolve it
+			if realPath, err := os.Readlink(execPath); err == nil {
+				if !strings.HasPrefix(realPath, "/") {
+					// Relative symlink, make it absolute
+					sourceDir = execPath[:strings.LastIndex(execPath, "/")+1] + realPath
+				} else {
+					sourceDir = realPath
+				}
+			}
+		}
+
+		// Get the directory containing the executable (where main.go should be)
+		sourceDir = sourceDir[:strings.LastIndex(sourceDir, "/")]
+
+		// Build the new binary
+		buildCmd := exec.Command("go", "build", "-o", execPath, "main.go")
+		buildCmd.Dir = sourceDir
+
+		if err := buildCmd.Run(); err != nil {
+			return models.BuildErrorMsg{Err: fmt.Errorf("failed to build: %w", err)}
+		}
+
+		// Signal build completion
+		return models.BuildCompleteMsg{}
+	}
+}
+
+func ReloadOrchestrator() error {
+	// Prepare arguments (skip program name)
+	args := os.Args[1:]
+
+	// Get the current executable path
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	// Use syscall.Exec to replace the current process with the newly built binary
+	env := os.Environ()
+	return syscall.Exec(execPath, append([]string{execPath}, args...), env)
+}

--- a/orchestrator/internal/utils/signals.go
+++ b/orchestrator/internal/utils/signals.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"gemini-orchestrator/internal/models"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func ListenForSignals() tea.Cmd {
+	return func() tea.Msg {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan,
+			syscall.SIGINT,  // Ctrl+C
+			syscall.SIGTERM, // Termination request
+			syscall.SIGHUP,  // Terminal disconnection
+			syscall.SIGQUIT, // Quit signal
+		)
+
+		sig := <-sigChan
+		return models.ShutdownMsg{Signal: sig}
+	}
+}

--- a/orchestrator/main.go
+++ b/orchestrator/main.go
@@ -4,674 +4,172 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
-	"os/signal"
 	"strings"
-	"syscall"
-	"time"
 
-	"github.com/charmbracelet/bubbles/cursor"
-	"github.com/charmbracelet/bubbles/spinner"
-	"github.com/charmbracelet/bubbles/textinput"
+	"gemini-orchestrator/internal/commands"
+	"gemini-orchestrator/internal/models"
+	"gemini-orchestrator/internal/ui"
+	"gemini-orchestrator/internal/utils"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
-var (
-	focusedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
-	blurredStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	titleStyle   = lipgloss.NewStyle().
-			Background(lipgloss.Color("62")).
-			Foreground(lipgloss.Color("230")).
-			Padding(0, 1).
-			MarginBottom(1)
-	suggestionStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#CBC8C6")).
-			Padding(0, 2)
-	selectedSuggestionStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#4E5EDE")).
-				Padding(0, 2)
-	inputBoxStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#CBC8C6")).
-			Padding(0, 1)
-	helpTextStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#CBC8C6")).
-			MarginTop(1).
-			Padding(0, 2)
-	messageStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#CBC8C6"))
-)
-
-var slashCommands = []string{
-	"/commit",
-	"/pr", 
-	"/issue",
-	"/help",
-	"/clear",
-	"/reload",
+type orchestratorModel struct {
+	models.Model
 }
 
-var modeShortcuts = []string{
-	"! for bash mode",
-	"/ for commands",
-	"@ for file paths",
-	"# to memorize",
+func (m orchestratorModel) Init() tea.Cmd {
+	return models.ListenForSignals()
 }
 
-var generalShortcuts = []string{
-	"double tap esc to clear input",
-	"shift + tab to auto-accept edits",
-	"ctrl + r for verbose output",
-	"shift + e for newline",
-	"ctrl + _ to undo",
-	"ctrl + z to suspend",
-}
-
-func distributeShortcuts(terminalWidth int) []string {
-	// Try 3 columns first (modes + general shortcuts with different spacing)
-	formatted := tryThreeColumnLayout(terminalWidth)
-	if formatted != nil {
-		return formatted
-	}
-
-	// Fallback to 2 columns (modes | all general shortcuts)
-	formatted = tryTwoColumnLayout(terminalWidth)
-	if formatted != nil {
-		return formatted
-	}
-
-	// Fallback to 1 column (everything stacked)
-	return tryOneColumnLayout()
-}
-
-func tryThreeColumnLayout(terminalWidth int) []string {
-	// Mode shortcuts in column 1, general shortcuts distributed in columns 2&3
-	maxRows := len(modeShortcuts)
-	generalPerCol := (len(generalShortcuts) + 1) / 2 // Split general shortcuts across 2 columns
-	if generalPerCol > maxRows {
-		maxRows = generalPerCol
-	}
-
-	// Create grid
-	grid := make([][]string, maxRows)
-	for i := range grid {
-		grid[i] = make([]string, 3)
-	}
-
-	// Fill column 1 with mode shortcuts
-	for i, shortcut := range modeShortcuts {
-		grid[i][0] = shortcut
-	}
-
-	// Fill columns 2&3 with general shortcuts
-	for i, shortcut := range generalShortcuts {
-		col := 1 + (i / generalPerCol)
-		row := i % generalPerCol
-		if col < 3 && row < maxRows {
-			grid[row][col] = shortcut
-		}
-	}
-
-	// Calculate widths: mode column uses 8 spaces, general columns use 4 spaces
-	maxWidths := make([]int, 3)
-	for _, row := range grid {
-		for i, cell := range row {
-			if len(cell) > maxWidths[i] {
-				maxWidths[i] = len(cell)
-			}
-		}
-	}
-
-	// Calculate total width with mixed spacing
-	totalWidth := maxWidths[0] + 8 + maxWidths[1] + 4 + maxWidths[2]
-	if totalWidth > terminalWidth-10 {
-		return nil // Doesn't fit
-	}
-
-	// Format with mixed spacing
-	var formatted []string
-	for _, row := range grid {
-		var line string
-		for i, cell := range row {
-			if i == 0 {
-				line = cell
-			} else if cell != "" {
-				spacing := 8 // Default to 8 spaces
-				if i == 2 {
-					spacing = 4 // 4 spaces between general columns
-				}
-				padding := maxWidths[i-1] - len(row[i-1]) + spacing
-				line += strings.Repeat(" ", padding) + cell
-			}
-		}
-		if strings.TrimSpace(line) != "" {
-			formatted = append(formatted, line)
-		}
-	}
-
-	return formatted
-}
-
-func tryTwoColumnLayout(terminalWidth int) []string {
-	// Mode shortcuts in column 1, all general shortcuts in column 2
-	maxRows := len(modeShortcuts)
-	if len(generalShortcuts) > maxRows {
-		maxRows = len(generalShortcuts)
-	}
-
-	// Create grid
-	grid := make([][]string, maxRows)
-	for i := range grid {
-		grid[i] = make([]string, 2)
-	}
-
-	// Fill columns
-	for i, shortcut := range modeShortcuts {
-		grid[i][0] = shortcut
-	}
-	for i, shortcut := range generalShortcuts {
-		grid[i][1] = shortcut
-	}
-
-	// Calculate widths
-	maxWidths := make([]int, 2)
-	for _, row := range grid {
-		for i, cell := range row {
-			if len(cell) > maxWidths[i] {
-				maxWidths[i] = len(cell)
-			}
-		}
-	}
-
-	// Check if it fits
-	totalWidth := maxWidths[0] + 8 + maxWidths[1]
-	if totalWidth > terminalWidth-10 {
-		return nil
-	}
-
-	// Format
-	var formatted []string
-	for _, row := range grid {
-		var line string
-		for i, cell := range row {
-			if i == 0 {
-				line = cell
-			} else if cell != "" {
-				padding := maxWidths[i-1] - len(row[i-1]) + 8
-				line += strings.Repeat(" ", padding) + cell
-			}
-		}
-		if strings.TrimSpace(line) != "" {
-			formatted = append(formatted, line)
-		}
-	}
-
-	return formatted
-}
-
-func tryOneColumnLayout() []string {
-	// Stack everything in one column
-	var formatted []string
-	formatted = append(formatted, modeShortcuts...)
-	formatted = append(formatted, generalShortcuts...)
-	return formatted
-}
-
-type model struct {
-	textInput          textinput.Model
-	messages           []string
-	suggestions        []string
-	selectedSuggestion int
-	showSuggestions    bool
-	showHelp           bool
-	width              int
-	height             int
-	spinner            spinner.Model
-	isBuilding         bool
-	showExitConfirm    bool
-}
-
-func initialModel() model {
-	ti := textinput.New()
-	ti.Placeholder = "Type your message..."
-	ti.Focus()
-	ti.CharLimit = 200
-	ti.Width = 50
-	ti.Cursor.SetMode(cursor.CursorStatic)
-
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
-
-	return model{
-		textInput:          ti,
-		messages:           []string{},
-		suggestions:        []string{},
-		selectedSuggestion: 0,
-		showSuggestions:    false,
-		showHelp:           false,
-		width:              80,
-		height:             24,
-		spinner:            s,
-		isBuilding:         false,
-		showExitConfirm:    false,
-	}
-}
-
-type buildCompleteMsg struct{}
-type buildErrorMsg struct{ err error }
-type shutdownMsg struct{ signal os.Signal }
-type ctrlCTimeoutMsg struct{}
-
-func (m model) Init() tea.Cmd {
-	return listenForSignals()
-}
-
-func listenForSignals() tea.Cmd {
-	return func() tea.Msg {
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, 
-			syscall.SIGINT,  // Ctrl+C
-			syscall.SIGTERM, // Termination request
-			syscall.SIGHUP,  // Terminal disconnection
-			syscall.SIGQUIT, // Quit signal
-		)
-		
-		sig := <-sigChan
-		return shutdownMsg{signal: sig}
-	}
-}
-
-func ctrlCTimeoutCmd() tea.Cmd {
-	return tea.Tick(time.Second, func(time.Time) tea.Msg {
-		return ctrlCTimeoutMsg{}
-	})
-}
-
-func (m *model) updateSuggestions() {
-	input := m.textInput.Value()
-
-	if strings.HasPrefix(input, "/") {
-		m.showHelp = false
-		oldSuggestions := m.suggestions
-		m.suggestions = []string{}
-		for _, cmd := range slashCommands {
-			if strings.HasPrefix(cmd, input) {
-				m.suggestions = append(m.suggestions, cmd)
-			}
-		}
-		m.showSuggestions = len(m.suggestions) > 0
-
-		// Only reset selection if suggestions changed or if we had no suggestions before
-		if len(oldSuggestions) == 0 || !slicesEqual(oldSuggestions, m.suggestions) {
-			m.selectedSuggestion = 0
-		} else if m.selectedSuggestion >= len(m.suggestions) {
-			// Clamp selection if it's out of bounds
-			m.selectedSuggestion = len(m.suggestions) - 1
-		}
-	} else {
-		m.showSuggestions = false
-		m.suggestions = []string{}
-	}
-}
-
-func slicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func buildAndReloadCmd() tea.Cmd {
-	return func() tea.Msg {
-		// Get the current executable path
-		execPath, err := os.Executable()
-		if err != nil {
-			return buildErrorMsg{err: fmt.Errorf("failed to get executable path: %w", err)}
-		}
-
-		// Get the source directory (where main.go is located)
-		// This handles symlinks by getting the directory of the actual binary
-		sourceDir := execPath
-		if info, err := os.Lstat(execPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
-			// It's a symlink, resolve it
-			if realPath, err := os.Readlink(execPath); err == nil {
-				if !strings.HasPrefix(realPath, "/") {
-					// Relative symlink, make it absolute
-					sourceDir = execPath[:strings.LastIndex(execPath, "/")+1] + realPath
-				} else {
-					sourceDir = realPath
-				}
-			}
-		}
-		
-		// Get the directory containing the executable (where main.go should be)
-		sourceDir = sourceDir[:strings.LastIndex(sourceDir, "/")]
-
-		// Build the new binary
-		buildCmd := exec.Command("go", "build", "-o", execPath, "main.go")
-		buildCmd.Dir = sourceDir
-		
-		if err := buildCmd.Run(); err != nil {
-			return buildErrorMsg{err: fmt.Errorf("failed to build: %w", err)}
-		}
-
-		// Signal build completion
-		return buildCompleteMsg{}
-	}
-}
-
-func reloadOrchestrator() error {
-	// Prepare arguments (skip program name)
-	args := os.Args[1:]
-
-	// Get the current executable path
-	execPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to get executable path: %w", err)
-	}
-
-	// Use syscall.Exec to replace the current process with the newly built binary
-	env := os.Environ()
-	return syscall.Exec(execPath, append([]string{execPath}, args...), env)
-}
-
-
-
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m orchestratorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
-		m.textInput.Width = msg.Width - 6 // Account for border and padding
+		m.Width = msg.Width
+		m.Height = msg.Height
+		m.TextInput.Width = msg.Width - 6
 		return m, nil
-	case buildCompleteMsg:
-		// Build completed successfully, now reload
-		m.isBuilding = false
-		if err := reloadOrchestrator(); err != nil {
-			m.messages = append(m.messages, fmt.Sprintf("❌ Failed to reload: %v", err))
+	case models.BuildCompleteMsg:
+		m.IsBuilding = false
+		if err := utils.ReloadOrchestrator(); err != nil {
+			m.Messages = append(m.Messages, fmt.Sprintf("❌ Failed to reload: %v", err))
 		}
 		return m, nil
-	case buildErrorMsg:
-		// Build failed
-		m.isBuilding = false
-		m.messages = append(m.messages, fmt.Sprintf("❌ Build failed: %v", msg.err))
+	case models.BuildErrorMsg:
+		m.IsBuilding = false
+		m.Messages = append(m.Messages, fmt.Sprintf("❌ Build failed: %v", msg.Err))
 		return m, nil
-	case shutdownMsg:
-		// Graceful shutdown requested (for signals other than SIGINT)
-		if msg.signal != syscall.SIGINT {
-			return m, tea.Quit
-		}
-		// SIGINT (Ctrl+C) handling is done in KeyMsg section
-		return m, nil
-	case ctrlCTimeoutMsg:
-		// Timeout for Ctrl+C confirmation - hide the confirmation message
-		m.showExitConfirm = false
+	case models.ShutdownMsg:
+		return m, tea.Quit
+	case models.CtrlCTimeoutMsg:
+		m.ShowExitConfirm = false
 		return m, nil
 	case tea.KeyMsg:
-		switch msg.Type {
-		case tea.KeyCtrlC:
-			if m.showExitConfirm {
-				// Second Ctrl+C within timeout window - exit
-				return m, tea.Quit
-			} else {
-				// First Ctrl+C - show confirmation and start timeout
-				m.showExitConfirm = true
-				return m, ctrlCTimeoutCmd()
-			}
-		case tea.KeyEsc:
-			if m.showExitConfirm {
-				// Esc cancels the exit confirmation
-				m.showExitConfirm = false
-				return m, nil
-			}
-			return m, tea.Quit
-		case tea.KeyBackspace:
-			// Cancel exit confirmation if showing
-			if m.showExitConfirm {
-				m.showExitConfirm = false
-			}
-			// Exit modes when backspacing on empty input
-			if m.textInput.Value() == "" {
-				m.showHelp = false
-				m.showSuggestions = false
-				m.suggestions = []string{}
-				return m, nil
-			}
-		case tea.KeyRunes:
-			// Cancel exit confirmation if showing
-			if m.showExitConfirm {
-				m.showExitConfirm = false
-			}
-			// Intercept ? character when input is empty
-			if len(msg.Runes) == 1 && string(msg.Runes[0]) == "?" && m.textInput.Value() == "" {
-				m.showHelp = !m.showHelp
-				m.showSuggestions = false
-				m.suggestions = []string{}
-				return m, nil
-			}
-		case tea.KeyEnter:
-			// Cancel exit confirmation if showing
-			if m.showExitConfirm {
-				m.showExitConfirm = false
-			}
-			if m.showSuggestions && len(m.suggestions) > 0 {
-				// Execute the selected suggestion immediately
-				inputValue := strings.TrimSpace(m.suggestions[m.selectedSuggestion])
-				m.textInput.SetValue(inputValue)
-				m.showSuggestions = false
-				// Fall through to execute the command
-			}
-			
-			if m.textInput.Value() != "" {
-				inputValue := strings.TrimSpace(m.textInput.Value())
-				
-				// Handle /reload command
-				if inputValue == "/reload" {
-					// Start building process
-					m.isBuilding = true
-					m.textInput.SetValue("")
-					m.showSuggestions = false
-					m.showHelp = false
-					return m, tea.Batch(m.spinner.Tick, buildAndReloadCmd())
-				}
-				
-				// Handle /commit command
-				if strings.HasPrefix(inputValue, "/commit") {
-					m.messages = append(m.messages, "⚠️ /commit command not yet implemented")
-					m.textInput.SetValue("")
-					m.showSuggestions = false
-					m.showHelp = false
-					return m, nil
-				}
-				
-				// Handle /pr command
-				if strings.HasPrefix(inputValue, "/pr") {
-					m.messages = append(m.messages, "⚠️ /pr command not yet implemented")
-					m.textInput.SetValue("")
-					m.showSuggestions = false
-					m.showHelp = false
-					return m, nil
-				}
-				
-				// Handle /issue command
-				if inputValue == "/issue" {
-					m.messages = append(m.messages, "⚠️ /issue command not yet implemented")
-					m.textInput.SetValue("")
-					m.showSuggestions = false
-					m.showHelp = false
-					return m, nil
-				}
-				
-				// Handle /clear command
-				if inputValue == "/clear" {
-					// Clear entire display and reset to initial state
-					composeUI(&m)
-					m.messages = []string{"Display cleared."}
-					m.textInput.SetValue("")
-					m.showSuggestions = false
-					m.showHelp = false
-					return m, nil
-				}
-				
-				m.messages = append(m.messages, m.textInput.Value())
-				m.textInput.SetValue("")
-				m.showSuggestions = false
-				m.showHelp = false
-			}
-		case tea.KeyUp:
-			// Cancel exit confirmation if showing
-			if m.showExitConfirm {
-				m.showExitConfirm = false
-			}
-			if m.showSuggestions && len(m.suggestions) > 0 {
-				if m.selectedSuggestion > 0 {
-					m.selectedSuggestion--
-				}
-				return m, nil
-			}
-		case tea.KeyDown:
-			// Cancel exit confirmation if showing
-			if m.showExitConfirm {
-				m.showExitConfirm = false
-			}
-			if m.showSuggestions && len(m.suggestions) > 0 {
-				if m.selectedSuggestion < len(m.suggestions)-1 {
-					m.selectedSuggestion++
-				}
-				return m, nil
-			}
-		case tea.KeyTab:
-			// Cancel exit confirmation if showing
-			if m.showExitConfirm {
-				m.showExitConfirm = false
-			}
-			if m.showSuggestions && len(m.suggestions) > 0 {
-				// Tab to complete + space
-				completed := m.suggestions[m.selectedSuggestion] + " "
-				m.textInput.SetValue(completed)
-				m.textInput.SetCursor(len(completed))
-				m.showSuggestions = false
-				return m, nil
-			}
-		}
+		return m.handleKeyMsg(msg)
 	}
 
 	// Update spinner if building
-	if m.isBuilding {
+	if m.IsBuilding {
 		var spinnerCmd tea.Cmd
-		m.spinner, spinnerCmd = m.spinner.Update(msg)
+		m.Spinner, spinnerCmd = m.Spinner.Update(msg)
 		cmd = tea.Batch(cmd, spinnerCmd)
 	}
 
 	var textInputCmd tea.Cmd
-	m.textInput, textInputCmd = m.textInput.Update(msg)
-	m.updateSuggestions()
+	m.TextInput, textInputCmd = m.TextInput.Update(msg)
+	m.UpdateSuggestions()
 	return m, tea.Batch(cmd, textInputCmd)
 }
 
-func renderHeader() string {
-	return titleStyle.Render("Gemini CLI Orchestrator") + "\n\n"
-}
-
-func renderContent(m model) string {
-	var content string
-	
-	// Messages history
-	if len(m.messages) > 0 {
-		for _, msg := range m.messages {
-			content += messageStyle.Render(fmt.Sprintf("> %s", msg)) + "\n"
+func (m orchestratorModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		if m.ShowExitConfirm {
+			return m, tea.Quit
+		} else {
+			m.ShowExitConfirm = true
+			return m, models.CtrlCTimeoutCmd()
 		}
-		content += "\n"
+	case tea.KeyEsc:
+		if m.ShowExitConfirm {
+			m.ShowExitConfirm = false
+			return m, nil
+		}
+		return m, tea.Quit
+	case tea.KeyBackspace:
+		if m.ShowExitConfirm {
+			m.ShowExitConfirm = false
+		}
+		if m.TextInput.Value() == "" {
+			m.ShowHelp = false
+			m.ShowSuggestions = false
+			m.Suggestions = []string{}
+			return m, nil
+		}
+	case tea.KeyRunes:
+		if m.ShowExitConfirm {
+			m.ShowExitConfirm = false
+		}
+		if len(msg.Runes) == 1 && string(msg.Runes[0]) == "?" && m.TextInput.Value() == "" {
+			m.ShowHelp = !m.ShowHelp
+			m.ShowSuggestions = false
+			m.Suggestions = []string{}
+			return m, nil
+		}
+	case tea.KeyEnter:
+		return m.handleEnterKey()
+	case tea.KeyUp:
+		return m.handleNavigationKey(true)
+	case tea.KeyDown:
+		return m.handleNavigationKey(false)
+	case tea.KeyTab:
+		return m.handleTabKey()
 	}
-	
-	return content
+	return m, nil
 }
 
-func renderInputBar(m model) string {
-	var inputBar string
-	
-	// Only show input if not building
-	if !m.isBuilding {
-		// Input with full-width border
-		inputBox := inputBoxStyle.Width(m.width - 2) // Full width minus small margin
-		inputBar += inputBox.Render(m.textInput.View())
+func (m orchestratorModel) handleEnterKey() (tea.Model, tea.Cmd) {
+	if m.ShowExitConfirm {
+		m.ShowExitConfirm = false
 	}
-	
-	return inputBar
+	if m.ShowSuggestions && len(m.Suggestions) > 0 {
+		inputValue := strings.TrimSpace(m.Suggestions[m.SelectedSuggestion])
+		m.TextInput.SetValue(inputValue)
+		m.ShowSuggestions = false
+	}
+
+	if m.TextInput.Value() != "" {
+		inputValue := strings.TrimSpace(m.TextInput.Value())
+		return m, commands.HandleCommand(inputValue, &m.Model)
+	}
+	return m, nil
 }
 
-func (m model) View() string {
-	var view string
-
-	// Composable UI layout
-	view += renderHeader()
-	view += renderContent(m)
-	
-	// Show building spinner if building
-	if m.isBuilding {
-		view += suggestionStyle.Render(fmt.Sprintf("%s Building and reloading...", m.spinner.View())) + "\n\n"
+func (m orchestratorModel) handleNavigationKey(isUp bool) (tea.Model, tea.Cmd) {
+	if m.ShowExitConfirm {
+		m.ShowExitConfirm = false
 	}
-	
-	view += renderInputBar(m)
-
-	// Only show UI elements if not building
-	if !m.isBuilding {
-		if m.showExitConfirm {
-			// Priority 1: Exit confirmation (overrides everything else)
-			view += helpTextStyle.Render("Press Ctrl+C again to exit (or Esc to cancel)")
-		} else if m.showSuggestions && len(m.suggestions) > 0 {
-			// Priority 2: Suggestions dropdown
-			view += "\n"
-			for i, suggestion := range m.suggestions {
-				if i == m.selectedSuggestion {
-					view += selectedSuggestionStyle.Render(suggestion) + "\n"
-				} else {
-					view += suggestionStyle.Render(suggestion) + "\n"
-				}
-			}
-			view += "\n"
-			view += blurredStyle.Render("↑/↓ to navigate • Tab to complete • Enter to execute")
-		} else if m.showHelp {
-			// Priority 3: Help shortcuts
-			view += "\n"
-			formattedShortcuts := distributeShortcuts(m.width)
-			for _, shortcut := range formattedShortcuts {
-				view += suggestionStyle.Render(shortcut) + "\n"
+	if m.ShowSuggestions && len(m.Suggestions) > 0 {
+		if isUp {
+			if m.SelectedSuggestion > 0 {
+				m.SelectedSuggestion--
 			}
 		} else {
-			// Priority 4: Default help prompt
-			view += helpTextStyle.Render("? for shortcuts")
+			if m.SelectedSuggestion < len(m.Suggestions)-1 {
+				m.SelectedSuggestion++
+			}
 		}
+		return m, nil
 	}
-
-	view += "\n"
-	view += "\n"
-
-	return view
+	return m, nil
 }
 
-func clearConsole() {
-	fmt.Print("\033[2J\033[H")
+func (m orchestratorModel) handleTabKey() (tea.Model, tea.Cmd) {
+	if m.ShowExitConfirm {
+		m.ShowExitConfirm = false
+	}
+	if m.ShowSuggestions && len(m.Suggestions) > 0 {
+		completed := m.Suggestions[m.SelectedSuggestion] + " "
+		m.TextInput.SetValue(completed)
+		m.TextInput.SetCursor(len(completed))
+		m.ShowSuggestions = false
+		return m, nil
+	}
+	return m, nil
 }
 
-func composeUI(m *model) {
-	// Reset UI state - Bubble Tea will handle the visual refresh automatically
-	// This is the recommended approach rather than direct console manipulation
+func (m orchestratorModel) View() string {
+	return ui.RenderView(m.Model)
 }
 
 func main() {
-	clearConsole()
-	
-	p := tea.NewProgram(initialModel())
+	ui.ClearConsole()
+
+	initialModel := models.InitialModel()
+	wrappedModel := orchestratorModel{Model: initialModel}
+
+	p := tea.NewProgram(wrappedModel)
 	if _, err := p.Run(); err != nil {
 		log.Fatal(err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Decouple core application logic from `main.go` into dedicated internal packages.

## Changes
- Introduce `commands` package for handling slash commands.
- Introduce `models` package for application state and custom messages.
- Introduce `ui` package for rendering and styling.
- Introduce `utils` package for build and signal handling.
- Improve code organization and maintainability.

🤖 Generated with [Gemini CLI](https://github.com/google-gemini/gemini-cli)